### PR TITLE
Improve positioning CSS for fontwatcher spans

### DIFF
--- a/src/core/fontwatchrunner.js
+++ b/src/core/fontwatchrunner.js
@@ -125,9 +125,9 @@ webfont.FontWatchRunner.prototype.getDefaultFontSize_ = function(defaultFonts) {
 webfont.FontWatchRunner.prototype.createHiddenElementWithFont_ = function(
     defaultFonts, opt_withoutFontFamily) {
   var variationCss = this.fvd_.expand(this.fontDescription_);
-  var styleString = "position:absolute;top:-999px;font-size:300px;" +
-    "width:auto;height:auto;line-height:normal;margin:0;padding:0;" +
-    "font-variant:normal;font-family:" + (opt_withoutFontFamily ? "" :
+  var styleString = "position:absolute;top:-999px;left:-999px;" +
+    "font-size:300px;width:auto;height:auto;line-height:normal;margin:0;" +
+    "padding:0;font-variant:normal;font-family:" + (opt_withoutFontFamily ? "" :
         this.nameHelper_.quote(this.fontFamily_) + ",") +
       defaultFonts + ";" + variationCss;
   var span = this.domHelper_.createElement('span', { 'style': styleString },


### PR DESCRIPTION
Fontwatcher spans are appended to the body and positioned absolutely offscreen
so that they don't affect the rendering of the page. Before, their top was set
to -999px, but the left position was not set. This means that the horizontal
position of each span was unchanged from what it would have been if it was
still in the document's flow.

Normally, this wasn't a problem, but if the user's page ends with inline or
floated elements, the horizontal position of these spans can be pushed to the
right and they can cause a horizontal scrollbar to appear temporarily on the
page while the fonts are loading.

Explicitly setting the left position to a negative value makes the positioning
of the font watcher spans totally deterministic and should ensure that
scrollbars never appear, no matter what markup or CSS the user places on the
page.
