### PR TITLE
Add support for recognizing Chrome Mobile (CrMo) on Android

### DIFF
--- a/src-test/core/useragenttest.js
+++ b/src-test/core/useragenttest.js
@@ -165,6 +165,22 @@ UserAgentTest.prototype.testBrowserIsAndroid = function() {
   assertTrue(userAgent.isSupportingWebFont());
 };
 
+UserAgentTest.prototype.testBrowserIsAndroidChromeMobile = function() {
+  var userAgentParser = new webfont.UserAgentParser(
+    "Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Nexus S Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7",
+    this.defaultDocument_);
+  var userAgent = userAgentParser.parse();
+
+  assertEquals("Chrome", userAgent.getName());
+  assertEquals("16.0.912.75", userAgent.getVersion());
+  assertEquals("Android", userAgent.getPlatform());
+  assertEquals("4.0.3", userAgent.getPlatformVersion());
+  assertEquals("AppleWebKit", userAgent.getEngine());
+  assertEquals("535.7", userAgent.getEngineVersion());
+  assertEquals(undefined, userAgent.getDocumentMode());
+  assertTrue(userAgent.isSupportingWebFont());
+};
+
 UserAgentTest.prototype.testBrowserIsFirefoxLettersVersion = function() {
   var userAgentParser = new webfont.UserAgentParser(
       "Mozilla/5.0 (X11; U; Linux i686; ru-RU; rv:1.9.2a1pre) Gecko/20090405 Ubuntu/9.04 (jaunty) Firefox/3.6a1pre",

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -195,7 +195,7 @@ webfont.UserAgentParser.prototype.parseWebKitUserAgentString_ = function() {
   }
   var name = webfont.UserAgentParser.UNKNOWN;
 
-  if (this.userAgent_.indexOf("Chrome") != -1) {
+  if (this.userAgent_.indexOf("Chrome") != -1 || this.userAgent_.indexOf("CrMo") != -1) {
     name = "Chrome";
   } else if (this.userAgent_.indexOf("Safari") != -1) {
     name = "Safari";
@@ -209,7 +209,7 @@ webfont.UserAgentParser.prototype.parseWebKitUserAgentString_ = function() {
         /Version\/([\d\.\w]+)/, 1);
   } else if (name == "Chrome") {
     version = this.getMatchingGroup_(this.userAgent_,
-        /Chrome\/([\d\.]+)/, 1);
+        /(Chrome|CrMo)\/([\d\.]+)/, 2);
   } else if (name == "AdobeAIR") {
     version = this.getMatchingGroup_(this.userAgent_,
         /AdobeAIR\/([\d\.]+)/, 1);


### PR DESCRIPTION
Now that Chrome Mobile is out for Android, we need a small change to the user agent parser to be able to recognize it, since it uses "CrMo" instead of "Chrome" in the user agent string. We still categorize this as "Chrome" and not a different name (like "CrMo") because the platform should be sufficient for distinguishing between desktop and mobile versions.
