### PR TITLE
Updated the Google Web Fonts API parser to accept family names with a plus sign

### DIFF
--- a/src-test/google/fontapiparsertest.js
+++ b/src-test/google/fontapiparsertest.js
@@ -207,3 +207,34 @@ FontApiParserTest.prototype.testHanumanIsForwardCompatible = function() {
   assertEquals(webfont.FontApiParser.INT_FONTS['khmer'],
       hanumanTestStrings);
 };
+
+FontApiParserTest.prototype.testPlusReplacedWithSpace = function() {
+  var fontFamilies = [ 'Erica+One', 'Droid+Serif::latin',
+      'Yanone+Kaffeesatz:400,700:latin'];
+  var fontApiParser = new webfont.FontApiParser(fontFamilies);
+
+  fontApiParser.parse();
+  var parsedFontFamilies = fontApiParser.getFontFamilies();
+
+  assertEquals(3, parsedFontFamilies.length);
+  assertEquals('Erica One', parsedFontFamilies[0]);
+  assertEquals('Droid Serif', parsedFontFamilies[1]);
+  assertEquals('Yanone Kaffeesatz', parsedFontFamilies[2]);
+  var variations = fontApiParser.getVariations();
+
+  var ericaOne = variations['Erica One'];
+  assertNotNull(ericaOne);
+  assertEquals(1, ericaOne.length);
+  assertEquals('n4', ericaOne[0]);
+
+  var droidSerif = variations['Droid Serif'];
+  assertNotNull(droidSerif);
+  assertEquals(1, droidSerif.length);
+  assertEquals('n4', droidSerif[0]);
+
+  var yanoneKaffeesatz = variations['Yanone Kaffeesatz'];
+  assertNotNull(yanoneKaffeesatz);
+  assertEquals(2, yanoneKaffeesatz.length);
+  assertEquals('n4', yanoneKaffeesatz[0]);
+  assertEquals('n7', yanoneKaffeesatz[1]);
+};

--- a/src/google/fontapiparser.js
+++ b/src/google/fontapiparser.js
@@ -37,7 +37,7 @@ webfont.FontApiParser.prototype.parse = function() {
 
   for (var i = 0; i < length; i++) {
     var elements = this.fontFamilies_[i].split(":");
-    var fontFamily = elements[0];
+    var fontFamily = elements[0].replace(/\+/g, " ");
     var variations = ['n4'];
 
     if (elements.length >= 2) {


### PR DESCRIPTION
This is confusing to users of the regular Google Web Fonts API that the js doesn't take a plus for a space. I've added support for it.
