### PR TITLE
Adding font variations to custom module

### DIFF
--- a/src/google/fontapiparser.js
+++ b/src/google/fontapiparser.js
@@ -16,16 +16,12 @@ webfont.FontApiParser.VARIATIONS = {
   'bold': 'n7',
   'italic': 'i4',
   'bolditalic': 'i7',
-  'oblique': 'o4',
-  'boldoblique': 'o7',
   'ul': 'n2',
   'l': 'n3',
   'r': 'n4',
   'b': 'n7',
   'i': 'i4',
-  'bi': 'i7',
-  'o': 'o4',
-  'bo': 'o7'
+  'bi': 'i7'
 };
 
 webfont.FontApiParser.INT_FONTS = {


### PR DESCRIPTION
I don’t really know if this is the best way to go about this, but it seems to be working for me. The code pretty much just reuses the FontApiParser in the custom module. This seems a little messy since it creates a strong dependency from custom onto google. But for me this was more practical then copying and pasting most of FontApiParser.

I also needed to make a change to FontApiParser so that it would support oblique variations. I’m not sure if I did it right… my changes are all in the definition of webfont.FontApiParser.VARIATIONS.

Anyway I think these changes should address issue "self-hosted font variations”.
