### PR TITLE
Add support for detecting Chrome OS with the user agent parser

### DIFF
--- a/src-test/core/useragenttest.js
+++ b/src-test/core/useragenttest.js
@@ -84,6 +84,22 @@ UserAgentTest.prototype.testBrowserIsChrome = function() {
   assertTrue(userAgent.isSupportingWebFont());
 };
 
+UserAgentTest.prototype.testBrowserIsChromeOS = function() {
+  var userAgentParser = new webfont.UserAgentParser(
+      "Mozilla/5.0 (X11; CrOS i686 1660.57.0) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.46 Safari/535.19",
+      this.defaultDocument_);
+  var userAgent = userAgentParser.parse();
+
+  assertEquals("Chrome", userAgent.getName());
+  assertEquals("18.0.1025.46", userAgent.getVersion());
+  assertEquals("CrOS", userAgent.getPlatform());
+  assertEquals("i686 1660.57.0", userAgent.getPlatformVersion());
+  assertEquals("AppleWebKit", userAgent.getEngine());
+  assertEquals("535.19", userAgent.getEngineVersion());
+  assertEquals(undefined, userAgent.getDocumentMode());
+  assertTrue(userAgent.isSupportingWebFont());
+};
+
 UserAgentTest.prototype.testBrowserIsSafari = function() {
   var userAgentParser = new webfont.UserAgentParser(
       "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; en-us) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10",

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -56,7 +56,7 @@ webfont.UserAgentParser.prototype.getPlatform_ = function() {
     return mobileOs;
   }
   var os = this.getMatchingGroup_(this.userAgent_,
-      /(Linux|Mac_PowerPC|Macintosh|Windows)/, 1);
+      /(Linux|Mac_PowerPC|Macintosh|Windows|CrOS)/, 1);
 
   if (os != "") {
     if (os == "Mac_PowerPC") {
@@ -71,10 +71,10 @@ webfont.UserAgentParser.prototype.getPlatform_ = function() {
  * @private
  */
 webfont.UserAgentParser.prototype.getPlatformVersion_ = function() {
-  var macVersion = this.getMatchingGroup_(this.userAgent_,
-      /(OS X|Windows NT|Android) ([^;)]+)/, 2);
-  if (macVersion) {
-    return macVersion;
+  var genericVersion = this.getMatchingGroup_(this.userAgent_,
+      /(OS X|Windows NT|Android|CrOS) ([^;)]+)/, 2);
+  if (genericVersion) {
+    return genericVersion;
   }
   var iVersion = this.getMatchingGroup_(this.userAgent_,
       /(iPhone )?OS ([\d_]+)/, 2);


### PR DESCRIPTION
This branch is a tiny change to add support for detecting Chrome OS with the user agent parser, so that we can load fonts there as well. Chrome OS supports WOFF for all versions that are available.
