### PR TITLE
Additional mobile browser detection

### DIFF
--- a/src-test/core/useragenttest.js
+++ b/src-test/core/useragenttest.js
@@ -312,6 +312,9 @@ UserAgentTest.prototype.testBrowserIsOperaBeforeVersion10 = function() {
 };
 
 UserAgentTest.prototype.testBrowserIsOperaMobileAndroid = function() {
+  // For the purposes of web font support, we consider Opera Mobile to be a
+  // version of full Opera on mobile devices, since the support for web fonts
+  // follows the same version numbers as the desktop versions.
   var userAgentParser = new webfont.UserAgentParser(
     "Opera/9.80 (Android 4.1.1; Linux; Opera Mobi/ADR-1207201819; U; en) Presto/2.10.254 Version/12.00",
     this.defaultDocument_);
@@ -326,6 +329,26 @@ UserAgentTest.prototype.testBrowserIsOperaMobileAndroid = function() {
   assertEquals(undefined, userAgent.getDocumentMode());
   assertTrue(userAgent.isSupportingWebFont());
 };
+
+UserAgentTest.prototype.testBrowserIsOperaMiniAndroid = function() {
+  // For the purposes of web font support, we consider Opera Mini to be a
+  // different browser from the full Opera, since it doesn't support web fonts
+  // and follows two separate versioning systems. We use the Opera Mini version
+  // instead of the more generic Opera version.
+  var userAgentParser = new webfont.UserAgentParser(
+    "Opera/9.80 (Android; Opera Mini/7.0.29952/28.2144; U; en) Presto/2.8.119 Version/11.10",
+    this.defaultDocument_);
+  var userAgent = userAgentParser.parse();
+
+  assertEquals("OperaMini", userAgent.getName());
+  assertEquals("7.0.29952", userAgent.getVersion());
+  assertEquals("Android", userAgent.getPlatform());
+  assertEquals("Unknown", userAgent.getPlatformVersion());
+  assertEquals("Presto", userAgent.getEngine());
+  assertEquals("2.8.119", userAgent.getEngineVersion());
+  assertEquals(undefined, userAgent.getDocumentMode());
+  assertFalse(userAgent.isSupportingWebFont());
+}
 
 UserAgentTest.prototype.testBrowserIsIEOnMac = function() {
   var userAgentParser = new webfont.UserAgentParser(

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -153,6 +153,21 @@ webfont.UserAgentParser.prototype.parseOperaUserAgentString_ = function() {
       engineVersion = geckoVersion;
     }
   }
+
+  // Check for Opera Mini first, since it looks like normal Opera
+  if (this.userAgent_.indexOf("Opera Mini/") != -1) {
+    var version = this.getMatchingGroup_(this.userAgent_, /Opera Mini\/([\d\.]+)/, 1);
+
+    if (version == "") {
+      version = webfont.UserAgentParser.UNKNOWN;
+    }
+
+    return new webfont.UserAgent("OperaMini", version, engineName,
+        engineVersion, this.getPlatform_(), this.getPlatformVersion_(),
+        this.getDocumentMode_(this.doc_), false);
+  }
+
+  // Otherwise, find version information for normal Opera or Opera Mobile
   if (this.userAgent_.indexOf("Version/") != -1) {
     var version = this.getMatchingGroup_(this.userAgent_, /Version\/([\d\.]+)/, 1);
 


### PR DESCRIPTION
This branch adds support for detecting a few more newly-released mobile browsers accurately.
- Firefox for Android (no detection code changes were necessary, so I just added a test with a UA)
- Opera Mobile for Android (no detection code changes were necessary, so I just added a test with a UA)
- Chrome for iOS (this was previously detected as Mobile Safari)

I'm aware that Chrome uses the iOS-provided web view as the rendering engine, which makes it somewhat the same as Mobile Safari from a font rendering perspective. However, the networking stack is different, and they may differentiate other parts over time, so I think it's worth detecting as Chrome so that it's easy to differentiate.

This branch also adds code to _prevent_ Opera Mini from being falsely recognized as a version of Opera that supports web fonts. For the purposes of our detection, I'm proposing that Opera Mobile (which supports web fonts and uses the same versioning system as desktop Opera) be treated as `"Opera"` while Opera Mini (which doesn't support web fonts and uses a separate versioning system) be treated as `"OperaMini"`.
