### PR TITLE
Media query support in custom font loader

### DIFF
--- a/src/core/domhelper.js
+++ b/src/core/domhelper.js
@@ -99,12 +99,17 @@ webfont.DomHelper.prototype.removeElement = function(node) {
  * @param {string} src The URL of the stylesheet.
  * @return {Element} a link element.
  */
-webfont.DomHelper.prototype.createCssLink = function(src) {
-  return this.createElement('link', {
+webfont.DomHelper.prototype.createCssLink = function(src, media) {
+  var opts = {
     'rel': 'stylesheet',
     'href': src
-  });
+  };
+  if ( typeof media !== 'undefined' ) {
+    opts.media = media;
+  }
+  return this.createElement('link', opts);
 };
+
 
 /**
  * Creates a link to a javascript document.

--- a/src/custom/customcss.js
+++ b/src/custom/customcss.js
@@ -22,7 +22,7 @@ webfont.CustomCss.prototype.load = function(onReady) {
   for (var i = 0, len = urls.length; i < len; i++) {
     var url = urls[i];
 
-    this.domHelper_.insertInto('head', this.domHelper_.createCssLink(url));
+    this.domHelper_.insertInto('head', this.domHelper_.createCssLink(url, this.configuration_['media']));
   }
   onReady(families);
 };


### PR DESCRIPTION
I've had a few responsive projects recently where I've wanted to only load webfonts in for larger screened devices, to avoid the extra size and http requests for mobile devices.

This small change makes it possible to specify a media attribute to be added to the `<link>` element that gets injected into the head (for the custom loader option), by adding a 'media' item, as follows:

``` js
WebFontConfig = {
  custom: { families: ['OneFont', 'AnotherFont'],
    urls: [ 'http://myotherwebfontprovider.com/stylesheet1.css',
      'http://yetanotherwebfontprovider.com/stylesheet2.css' ],
   media: 'screen and (min-width: 480px)' }
};
```
