### PR TITLE
Protect against the user overriding CSS properties on our test span.

### DIFF
--- a/src-test/core/fontvariationdescriptiontest.js
+++ b/src-test/core/fontvariationdescriptiontest.js
@@ -56,6 +56,12 @@ FontVariationDescriptionTest.prototype.testExpandFontStyle = function() {
   assertEquals('font-style:oblique;font-weight:400;', this.fvd_.expand('o4'));
 };
 
+FontVariationDescriptionTest.prototype.testExpandFontStyleImportant = function() {
+  assertEquals('font-style:normal !important;font-weight:400 !important;', this.fvd_.expand('n4', true));
+  assertEquals('font-style:italic !important;font-weight:400 !important;', this.fvd_.expand('i4', true));
+  assertEquals('font-style:oblique !important;font-weight:400 !important;', this.fvd_.expand('o4', true));
+};
+
 FontVariationDescriptionTest.prototype.testExpandFontWeight = function() {
   assertEquals('font-style:normal;font-weight:100;', this.fvd_.expand('n1'));
   assertEquals('font-style:normal;font-weight:200;', this.fvd_.expand('n2'));

--- a/src/core/fontvariationdescription.js
+++ b/src/core/fontvariationdescription.js
@@ -57,10 +57,10 @@ webfont.FontVariationDescription.Item.prototype.compact = function(output, value
   }
 }
 
-webfont.FontVariationDescription.Item.prototype.expand = function(output, value) {
+webfont.FontVariationDescription.Item.prototype.expand = function(output, value, opt_important) {
   for (var i = 0; i < this.values_.length; i++) {
     if (value == this.values_[i][0]) {
-      output[this.index_] = this.property_ + ':' + this.values_[i][1];
+      output[this.index_] = this.property_ + ':' + this.values_[i][1] + (opt_important ? ' !important' : '');
       return;
     }
   }
@@ -94,10 +94,11 @@ webfont.FontVariationDescription.prototype.compact = function(input) {
 /**
  * Expands a FVD string into equivalent CSS declarations.
  * @param {string} fvd The FVD string, such as 'n4'.
+ * @param {boolean=} opt_important Whether or not !important should be appended.
  * @return {?string} The equivalent CSS such as
  *    'font-weight:normal;font-style:italic' or null if it cannot be parsed.
  */
-webfont.FontVariationDescription.prototype.expand = function(fvd) {
+webfont.FontVariationDescription.prototype.expand = function(fvd, opt_important) {
   if (fvd.length != 2) {
     return null;
   }
@@ -109,7 +110,7 @@ webfont.FontVariationDescription.prototype.expand = function(fvd) {
     var key = fvd.substr(i, 1);
     var values = this.values_[property];
     var item = new webfont.FontVariationDescription.Item(i, property, values);
-    item.expand(result, key);
+    item.expand(result, key, opt_important);
   }
 
   if (result[0] && result[1]) {

--- a/src/core/fontwatchrunner.js
+++ b/src/core/fontwatchrunner.js
@@ -155,12 +155,12 @@ webfont.FontWatchRunner.prototype.createHiddenElementWithFont_ = function(
 
 webfont.FontWatchRunner.prototype.computeStyleString_ = function(defaultFonts,
     fontDescription, opt_withoutFontFamily) {
-  var variationCss = this.fvd_.expand(fontDescription);
-  var styleString = "position:absolute;top:-999px;left:-999px;" +
-      "font-size:300px;width:auto;height:auto;line-height:normal;margin:0;" +
-      "padding:0;font-variant:normal;font-family:"
+  var variationCss = this.fvd_.expand(fontDescription, true);
+  var styleString = "position:absolute !important;top:-999px !important;left:-999px !important;" +
+      "font-size:300px !important;width:auto !important;height:auto !important;line-height:normal !important;margin:0 !important;" +
+      "padding:0 !important;font-variant:normal !important;font-family:"
       + (opt_withoutFontFamily ? "" :
         this.nameHelper_.quote(this.fontFamily_) + ",")
-      + defaultFonts + ";" + variationCss;
+      + defaultFonts + " !important;" + variationCss;
   return styleString;
 };


### PR DESCRIPTION
This pull request protects our test span against accidental overriding of font properties using `!important`. This should fix #70.
