### PR TITLE
Add support for BlackBerry

### DIFF
--- a/src-test/core/useragenttest.js
+++ b/src-test/core/useragenttest.js
@@ -196,8 +196,23 @@ UserAgentTest.prototype.testBrowserIsIPhone = function() {
   assertTrue(userAgent.isSupportingWebFont());
 };
 
-
 UserAgentTest.prototype.testBrowserIsAndroid = function() {
+  var userAgentParser = new webfont.UserAgentParser(
+      "Mozilla/5.0 (Linux; U; Android 2.2.1; en-ca; LG-P505R Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+      this.defaultDocument_);
+  var userAgent = userAgentParser.parse();
+
+  assertEquals("BuiltinBrowser", userAgent.getName());
+  assertEquals("Unknown", userAgent.getVersion());
+  assertEquals("Android", userAgent.getPlatform());
+  assertEquals("2.2.1", userAgent.getPlatformVersion());
+  assertEquals("AppleWebKit", userAgent.getEngine());
+  assertEquals("533.1", userAgent.getEngineVersion());
+  assertEquals(undefined, userAgent.getDocumentMode());
+  assertTrue(userAgent.isSupportingWebFont());
+};
+
+UserAgentTest.prototype.testBrowserIsOldUnsupportedAndroid = function() {
   var userAgentParser = new webfont.UserAgentParser(
       "Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; Nexus One Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17",
       this.defaultDocument_);
@@ -210,7 +225,7 @@ UserAgentTest.prototype.testBrowserIsAndroid = function() {
   assertEquals("AppleWebKit", userAgent.getEngine());
   assertEquals("530.17", userAgent.getEngineVersion());
   assertEquals(undefined, userAgent.getDocumentMode());
-  assertTrue(userAgent.isSupportingWebFont());
+  assertFalse(userAgent.isSupportingWebFont());
 };
 
 UserAgentTest.prototype.testBrowserIsAndroidChromeMobile = function() {

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -270,6 +270,8 @@ webfont.UserAgentParser.prototype.parseWebKitUserAgentString_ = function() {
       this.getMajorVersion_(version) == 2 && parseInt(minor, 10) >= 5;
   } else if (platform == "BlackBerry") {
     supportWebFont = parseInt(platformVersion, 10) >= 10;
+  } else if (platform == "Android") {
+    supportWebFont = parseFloat(platformVersion) > 2.1;
   } else {
     var minor = this.getMatchingGroup_(webKitVersion, /\d+\.(\d+)/, 1);
     supportWebFont = this.getMajorVersion_(webKitVersion) >= 526 ||


### PR DESCRIPTION
This pull request:
- adds support for BlackBerry in the UserAgentParser.
- creates a new "browser name" to refer to the built in browser app on mobile platforms called "BuiltinBrowser". This is used to give these unnamed browsers a common name. We switched the built in Android browser app to be classified as "BuiltinBrowser" instead of "Mobile Safari".
- Changes Android webfont support detection to use the platformVersion instead of the WebKit version.
