### PR TITLE
Add cache buster to fonts.com config

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -61,7 +61,8 @@ When using [Fonts.com web fonts][mtiwfs]
     <script type="text/javascript">
       WebFont.load({
         monotype: {
-          projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'
+          projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+          version: 12345 // (optional, flushes the CDN cache)
         }
       });
     </script>

--- a/src/monotype/monotype_script.js
+++ b/src/monotype/monotype_script.js
@@ -39,6 +39,7 @@ webfont.MonotypeScript.SCRIPTID = '__MonotypeAPIScript__';
 webfont.MonotypeScript.prototype.supportUserAgent = function (userAgent, support) {
   var self = this;
   var projectId = self.configuration_['projectId'];
+  var version = self.configuration_['version'];
   if (projectId) {
     var sc = self.domHelper_.createElement("script");
     sc["id"] = webfont.MonotypeScript.SCRIPTID + projectId;
@@ -68,7 +69,7 @@ webfont.MonotypeScript.prototype.supportUserAgent = function (userAgent, support
       }
     };
 
-    sc["src"] = self.getScriptSrc(projectId);
+    sc["src"] = self.getScriptSrc(projectId, version);
     this.domHelper_.insertInto('head', sc);
   }
   else {
@@ -76,10 +77,10 @@ webfont.MonotypeScript.prototype.supportUserAgent = function (userAgent, support
   }
 };
 
-webfont.MonotypeScript.prototype.getScriptSrc = function (projectId) {
+webfont.MonotypeScript.prototype.getScriptSrc = function (projectId, version) {
   var p = this.domHelper_.getProtocol();
   var api = (this.configuration_['api'] || 'fast.fonts.com/jsapi').replace(/^.*http(s?):(\/\/)?/, "");
-  return p + "//" + api + '/' + projectId + '.js';
+  return p + "//" + api + '/' + projectId + '.js' + ( version ? '?v='+ version : '' );
 };
 
 webfont.MonotypeScript.prototype.load = function (onReady) {


### PR DESCRIPTION
Allow a version to be added to the monotype config, this will bust the cache on their CDN.
