### PR TITLE
Do not export addModule as part of the global API.

### DIFF
--- a/src/core/browserinfo.js
+++ b/src/core/browserinfo.js
@@ -1,7 +1,6 @@
 goog.provide('webfont.BrowserInfo');
 
 /**
- * @export
  * @constructor
  * @param {boolean} webfontSupport
  * @param {boolean} webKitFallbackBug

--- a/src/core/initialize.js
+++ b/src/core/initialize.js
@@ -32,4 +32,3 @@ var globalNamespaceObject = window[globalName] = (function() {
 
 // Export the public API.
 globalNamespaceObject['load'] = globalNamespaceObject.load;
-globalNamespaceObject['addModule'] = globalNamespaceObject.addModule;

--- a/src/core/useragent.js
+++ b/src/core/useragent.js
@@ -1,7 +1,6 @@
 goog.provide('webfont.UserAgent');
 
 /**
- * @export
  * @param {string} name
  * @param {string} version
  * @param {string} engine
@@ -28,7 +27,6 @@ goog.scope(function () {
   var UserAgent = webfont.UserAgent;
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getName = function() {
@@ -36,7 +34,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getVersion = function() {
@@ -44,7 +41,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getEngine = function() {
@@ -52,7 +48,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getEngineVersion = function() {
@@ -60,7 +55,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getPlatform = function() {
@@ -68,7 +62,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {string}
    */
   UserAgent.prototype.getPlatformVersion = function() {
@@ -76,7 +69,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {number|undefined}
    */
   UserAgent.prototype.getDocumentMode = function() {
@@ -84,7 +76,6 @@ goog.scope(function () {
   };
 
   /**
-   * @export
    * @return {webfont.BrowserInfo}
    */
   UserAgent.prototype.getBrowserInfo = function() {


### PR DESCRIPTION
_Ready to deploy._ This pull request gets rid of `addModule` as part of the public webfontloader API. The reasons for removal are:
- It isn't documented.
- It doesn't work. The module API was never exported so all module functions called by the webfontloader core were renamed by the compiler which dynamically added modules would never know about.
- It is slightly smaller in file size: 18187 bytes (6747 bytes gzipped) before, versus 17384 bytes (6493 bytes gzipped) after.

This also means the `BrowserInfo` and `UserAgent` APIs are now private since they were only used by `addModule`.
