### PR TITLE
Fix configurable timeout on the Google lastresortwebkitfontwatchrunner

### DIFF
--- a/src/google/lastresortwebkitfontwatchrunner.js
+++ b/src/google/lastresortwebkitfontwatchrunner.js
@@ -92,7 +92,7 @@ goog.scope(function () {
         (!this.webKitLastResortFontWidths_[widthA] &&
          !this.webKitLastResortFontWidths_[widthB])) {
       this.finish_(this.activeCallback_);
-    } else if (goog.now() - this.started_ >= 5000) {
+    } else if (this.hasTimedOut_()) {
 
       // In order to handle the fact that a font could be the same size as the
       // default browser font on a webkit browser, mark the font as active


### PR DESCRIPTION
_Ready to deploy._ Reported here: http://stackoverflow.com/questions/15713283/webfont-loader-doesnt-seem-to-respect-timeout-property
