### PR TITLE
Add aria-hidden=true to the test spans so screen readers do not read the test strings out loud

### DIFF
--- a/src/core/fontruler.js
+++ b/src/core/fontruler.js
@@ -10,7 +10,9 @@ goog.provide('webfont.FontRuler');
 webfont.FontRuler = function (domHelper, fontTestString) {
   this.domHelper_ = domHelper;
   this.fontTestString_ = fontTestString;
-  this.el_ = this.domHelper_.createElement('span', {}, this.fontTestString_);
+  this.el_ = this.domHelper_.createElement('span', {
+    "aria-hidden": "true"
+  }, this.fontTestString_);
 };
 
 goog.scope(function () {


### PR DESCRIPTION
_Needs review._ This was reported to Typekit support.
