### PR TITLE
Make the name of the global object configurable at compile-time.

### DIFF
--- a/src/core/initialize.js
+++ b/src/core/initialize.js
@@ -9,11 +9,15 @@ goog.require('webfont.WebFont');
  */
 webfont.FontTestStrings;
 
-// Name of the global object.
-var globalName = 'WebFont';
+/**
+ * Name of the global object
+ *
+ * @define {string}
+ */
+var GLOBAL_NAME = 'WebFont';
 
 // Provide an instance of WebFont in the global namespace.
-var globalNamespaceObject = window[globalName] = (function() {
+var globalNamespaceObject = window[GLOBAL_NAME] = (function() {
   var userAgentParser = new webfont.UserAgentParser(navigator.userAgent, document);
   var userAgent = userAgentParser.parse();
   var fontModuleLoader = new webfont.FontModuleLoader();


### PR DESCRIPTION
_Needs review._ This doesn't change anything in the webfontloader but allows us to internally compile different versions of the webfontloader and use them together for integration testing.
