### PR TITLE
Fix incorrect Chrome browser version string

### DIFF
--- a/spec/core/useragentparser_spec.js
+++ b/spec/core/useragentparser_spec.js
@@ -19,8 +19,13 @@ describe('UserAgentParser', function () {
           return false;
         }
 
-        if (actual.getParsedVersion().ne(expected.version)) {
-          this.message = msg('version', actual.getParsedVersion(), expected.version);
+        if (actual.getParsedVersion().ne(expected.parsedVersion)) {
+          this.message = msg('parsed version', actual.getParsedVersion(), expected.parsedVersion);
+          return false;
+        }
+
+        if (actual.getVersion() !== expected.version) {
+          this.message = msg('version', actual.getVersion(), expected.version);
           return false;
         }
 
@@ -29,8 +34,13 @@ describe('UserAgentParser', function () {
           return false;
         }
 
-        if (actual.getParsedPlatformVersion().ne(expected.platformVersion)) {
-          this.message = msg('platform version', actual.getParsedPlatformVersion(), expected.platformVersion);
+        if (actual.getParsedPlatformVersion().ne(expected.parsedPlatformVersion)) {
+          this.message = msg('platform parsed version', actual.getParsedPlatformVersion(), expected.parsedPlatformVersion);
+          return false;
+        }
+
+        if (actual.getPlatformVersion() !== expected.platformVersion) {
+          this.message = msg('platform version', actual.getPlatformVersion(), expected.platformVersion);
           return false;
         }
 
@@ -39,8 +49,13 @@ describe('UserAgentParser', function () {
           return false;
         }
 
-        if (actual.getParsedEngineVersion().ne(expected.engineVersion)) {
-          this.message = msg('engine version', actual.getParsedEngineVersion(), expected.engineVersion);
+        if (actual.getParsedEngineVersion().ne(expected.parsedEngineVersion)) {
+          this.message = msg('engine parsed version', actual.getParsedEngineVersion(), expected.parsedEngineVersion);
+          return false;
+        }
+
+        if (actual.getEngineVersion() !== expected.engineVersion) {
+          this.message = msg('engine version', actual.getEngineVersion(), expected.engineVersion);
           return false;
         }
 
@@ -74,7 +89,7 @@ describe('UserAgentParser', function () {
       return new UserAgentParser(str, {}).getPlatformVersionString_();
     }
 
-    it('should parse Linux versions correctly', function () {
+    it('should parse Linux parsedVersions correctly', function () {
       expect(parsePlatformVersion('(Linux; U; en-us; KFJWI Build/IML74K)')).toEqual('Unknown');
       expect(parsePlatformVersion('(Linux i686; U; en)')).toEqual('Unknown');
       expect(parsePlatformVersion('(X11; Linux i686; U; Linux Mint; nb)')).toEqual('Unknown');
@@ -84,7 +99,7 @@ describe('UserAgentParser', function () {
       expect(parsePlatformVersion('(X11; Linux 10.1; U; en-US)')).toEqual('10.1');
     });
 
-    it('should parse ChromeOS versions correctly', function () {
+    it('should parse ChromeOS parsedVersions correctly', function () {
       expect(parsePlatformVersion('(X11; CrOS i686 1660.57.0)')).toEqual('1660.57.0');
     });
   });
@@ -99,11 +114,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.5'))
         .toMatchUserAgent({
           name: 'AdobeAIR',
-          version: new Version(2, 5),
+          parsedVersion: new Version(2, 5),
+          version: '2.5',
           platform: 'Macintosh',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 9),
+          parsedEngineVersion: new Version(531, 9),
+          engineVersion: '531.9',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -117,11 +135,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/531.9 (KHTML, like Gecko) AdobeAIR/2.0'))
         .toMatchUserAgent({
           name: 'AdobeAIR',
-          version: new Version(2, 0),
+          parsedVersion: new Version(2, 0),
+          version: '2.0',
           platform: 'Macintosh',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 9),
+          parsedEngineVersion: new Version(531, 9),
+          engineVersion: '531.9',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -137,11 +158,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 GTB7.1'))
         .toMatchUserAgent({
           name: 'Firefox',
-          version: new Version(3, 6, 3),
+          parsedVersion: new Version(3, 6, 3),
+          version: '3.6.3',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 5),
+          parsedPlatformVersion: new Version(10, 5),
+          platformVersion: '10.5',
           engine: 'Gecko',
-          engineVersion: new Version(1, 9, 2, 3),
+          parsedEngineVersion: new Version(1, 9, 2, 3),
+          engineVersion: '1.9.2.3',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -153,11 +177,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; U; Linux i686; ru-RU; rv:1.9.2a1pre) Gecko/20090405 Ubuntu/9.04 (jaunty) Firefox/3.6a1pre'))
         .toMatchUserAgent({
           name: 'Firefox',
-          version: new Version(3, 6, null, 'a1pre'),
+          parsedVersion: new Version(3, 6, null, 'a1pre'),
+          version: '3.6a1pre',
           platform: 'Linux',
-          platformVersion: new Version(), //'i686'
+          parsedPlatformVersion: new Version(), //'i686'
+          platformVersion: 'Unknown',
           engine: 'Gecko',
-          engineVersion: new Version(1, 9, 2, 'a1pre'),
+          parsedEngineVersion: new Version(1, 9, 2, 'a1pre'),
+          engineVersion: '1.9.2a1pre',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -171,11 +198,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:2.0b1) Gecko/20100630 Firefox/4.0b1'))
         .toMatchUserAgent({
           name: 'Firefox',
-          version: new Version(4, 0, null, 'b1'),
+          parsedVersion: new Version(4, 0, null, 'b1'),
+          version: '4.0b1',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 6),
+          parsedPlatformVersion: new Version(10, 6),
+          platformVersion: '10.6',
           engine: 'Gecko',
-          engineVersion: new Version(2, 0, 'b1'),
+          parsedEngineVersion: new Version(2, 0, 'b1'),
+          engineVersion: '2.0b1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -186,16 +216,19 @@ describe('UserAgentParser', function () {
       });
 
       it('should detect Firefox on Android', function () {
-        // This useragent has been slightly doctored with versions to ensure the right
+        // This useragent has been slightly doctored with parsedVersions to ensure the right
         // info is coming from the right places.
         expect(parse('Mozilla/5.0 (Android; Mobile; rv:13.0) Gecko/15.0 Firefox/14.0'))
         .toMatchUserAgent({
           name: 'Firefox',
-          version: new Version(14, 0),
+          parsedVersion: new Version(14, 0),
+          version: '14.0',
           platform: 'Android',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'Gecko',
-          engineVersion: new Version(13, 0),
+          parsedEngineVersion: new Version(13, 0),
+          engineVersion: '13.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -209,11 +242,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.19) Gecko/20081202 Firefox (Debian-2.0.0.19-0etch1)'))
         .toMatchUserAgent({
           name: 'Firefox',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: '',
           platform: 'Linux',
-          platformVersion: new Version(), //'i686'
+          parsedPlatformVersion: new Version(), //'i686'
+          platformVersion: 'Unknown',
           engine: 'Gecko',
-          engineVersion: new Version(1, 8, 1, 19),
+          parsedEngineVersion: new Version(1, 8, 1, 19),
+          engineVersion: '1.8.1.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -229,11 +265,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; en-US) AppleWebKit/533.2 (KHTML, like Gecko) Chrome/5.0.342.9 Safari/533.2'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(5, 0, 342, 9),
+          parsedVersion: new Version(5, 0, 342, 9),
+          version: '5.0.342.9',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 5, 8),
+          parsedPlatformVersion: new Version(10, 5, 8),
+          platformVersion: '10_5_8',
           engine: 'AppleWebKit',
-          engineVersion: new Version(533, 2),
+          parsedEngineVersion: new Version(533, 2),
+          engineVersion: '533.2',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -247,11 +286,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; CrOS i686 1660.57.0) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.46 Safari/535.19'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(18, 0, 1025, 46),
+          parsedVersion: new Version(18, 0, 1025, 46),
+          version: '18.0.1025.46',
           platform: 'CrOS',
-          platformVersion: new Version(1660, 57, 0),
+          parsedPlatformVersion: new Version(1660, 57, 0),
+          platformVersion: '1660.57.0',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -265,11 +307,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Nexus S Build/IML74K) AppleWebKit/535.7 (KHTML, like Gecko) CrMo/16.0.912.75 Mobile Safari/535.7'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(16, 0, 912, 75),
+          parsedVersion: new Version(16, 0, 912, 75),
+          version: '16.0.912.75',
           platform: 'Android',
-          platformVersion: new Version(4, 0, 3),
+          parsedPlatformVersion: new Version(4, 0, 3),
+          platformVersion: '4.0.3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 7),
+          parsedEngineVersion: new Version(535, 7),
+          engineVersion: '535.7',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -281,11 +326,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; Android 4.2.2; SGH-M919 Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(25, 0, 1364, 169),
+          parsedVersion: new Version(25, 0, 1364, 169),
+          version: '25.0.1364.169',
           platform: 'Android',
-          platformVersion: new Version(4, 2, 2),
+          parsedPlatformVersion: new Version(4, 2, 2),
+          platformVersion: '4.2.2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(537, 22),
+          parsedEngineVersion: new Version(537, 22),
+          engineVersion: '537.22',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -299,11 +347,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPad; U; CPU OS 5_1_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(19, 0, 1084, 60),
+          parsedVersion: new Version(19, 0, 1084, 60),
+          version: '19.0.1084.60',
           platform: 'iPad',
-          platformVersion: new Version(5, 1, 1),
+          parsedPlatformVersion: new Version(5, 1, 1),
+          platformVersion: '5_1_1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 46, 0),
+          parsedEngineVersion: new Version(534, 46, 0),
+          engineVersion: '534.46.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -317,11 +368,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPod; U; CPU iPhone OS 5_1_1 like Mac OS X; en-us) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/7534.48.3'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(19, 0, 1084, 60),
+          parsedVersion: new Version(19, 0, 1084, 60),
+          version: '19.0.1084.60',
           platform: 'iPod',
-          platformVersion: new Version(5, 1, 1),
+          parsedPlatformVersion: new Version(5, 1, 1),
+          platformVersion: '5_1_1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 46, 0),
+          parsedEngineVersion: new Version(534, 46, 0),
+          engineVersion: '534.46.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -337,11 +391,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; en-us) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0, 4),
+          parsedVersion: new Version(4, 0, 4),
+          version: '4.0.4',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 5, 8),
+          parsedPlatformVersion: new Version(10, 5, 8),
+          platformVersion: '10_5_8',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 21, 8),
+          parsedEngineVersion: new Version(531, 21, 8),
+          engineVersion: '531.21.8',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -353,11 +410,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_4_11; tr) AppleWebKit/528.4+ (KHTML, like Gecko) Version/4.0dp1 Safari/526.11.2'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0, null, 'dp1'),
+          parsedVersion: new Version(4, 0, null, 'dp1'),
+          version: '4.0dp1',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 4, 11),
+          parsedPlatformVersion: new Version(10, 4, 11),
+          platformVersion: '10_4_11',
           engine: 'AppleWebKit',
-          engineVersion: new Version(528, 4),
+          parsedEngineVersion: new Version(528, 4),
+          engineVersion: '528.4+',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -371,11 +431,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7D11 Safari/528.16'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0),
+          parsedVersion: new Version(4, 0),
+          version: '4.0',
           platform: 'iPhone',
-          platformVersion: new Version(3, 1, 2),
+          parsedPlatformVersion: new Version(3, 1, 2),
+          platformVersion: '3_1_2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(528, 18),
+          parsedEngineVersion: new Version(528, 18),
+          engineVersion: '528.18',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -389,11 +452,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0, 4),
+          parsedVersion: new Version(4, 0, 4),
+          version: '4.0.4',
           platform: 'iPad',
-          platformVersion: new Version(3, 2),
+          parsedPlatformVersion: new Version(3, 2),
+          platformVersion: '3_2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 21, 10),
+          parsedEngineVersion: new Version(531, 21, 10),
+          engineVersion: '531.21.10',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -405,11 +471,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B360 Safari/531.21.10"'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0, 4),
+          parsedVersion: new Version(4, 0, 4),
+          version: '4.0.4',
           platform: 'iPad',
-          platformVersion: new Version(3, 2),
+          parsedPlatformVersion: new Version(3, 2),
+          platformVersion: '3_2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 21, 10),
+          parsedEngineVersion: new Version(531, 21, 10),
+          engineVersion: '531.21.10',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -421,11 +490,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPad; U; CPU OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B334b Safari/531.21.10'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0, 4),
+          parsedVersion: new Version(4, 0, 4),
+          version: '4.0.4',
           platform: 'iPad',
-          platformVersion: new Version(3, 2),
+          parsedPlatformVersion: new Version(3, 2),
+          platformVersion: '3_2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(531, 21, 10),
+          parsedEngineVersion: new Version(531, 21, 10),
+          engineVersion: '531.21.10',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -439,11 +511,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPod; U; CPU iPhone OS 2_2_1 like Mac OS X; en-us) AppleWebKit/525.18.1 (KHTML, like Gecko) Mobile/5H11a'))
         .toMatchUserAgent({
           name: 'Unknown',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'iPod',
-          platformVersion: new Version(2, 2, 1),
+          parsedPlatformVersion: new Version(2, 2, 1),
+          platformVersion: '2_2_1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(525, 18, 1),
+          parsedEngineVersion: new Version(525, 18, 1),
+          engineVersion: '525.18.1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -455,11 +530,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (iPod; U; CPU iPhone OS 3_1 like Mac OS X; en-us) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7C144 Safari/528.16'))
         .toMatchUserAgent({
           name: 'Safari',
-          version: new Version(4, 0),
+          parsedVersion: new Version(4, 0),
+          version: '4.0',
           platform: 'iPod',
-          platformVersion: new Version(3, 1),
+          parsedPlatformVersion: new Version(3, 1),
+          platformVersion: '3_1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(528, 18),
+          parsedEngineVersion: new Version(528, 18),
+          engineVersion: '528.18',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -475,11 +553,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; InfoPath.2; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(7, 0),
+          parsedVersion: new Version(7, 0),
+          version: '7.0',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'MSIE',
-          engineVersion: new Version(7, 0),
+          parsedEngineVersion: new Version(7, 0),
+          engineVersion: '7.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -491,11 +572,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; Media Center PC 3.0; .NET CLR 1.0.3705; .NET CLR 1.1.4322; .NET CLR 2.0.50727; InfoPath.1)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(7, 0, null, 'b'),
+          parsedVersion: new Version(7, 0, null, 'b'),
+          version: '7.0b',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'MSIE',
-          engineVersion: new Version(7, 0, null, 'b'),
+          parsedEngineVersion: new Version(7, 0, null, 'b'),
+          engineVersion: '7.0b',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -509,11 +593,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(7, 0),
+          parsedVersion: new Version(7, 0),
+          version: '7.0',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'MSIE',
-          engineVersion: new Version(7, 0),
+          parsedEngineVersion: new Version(7, 0),
+          engineVersion: '7.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -527,11 +614,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; ARM; Touch; IEMobile/10.0; <Manufacturer>; <Device>; <Operator>)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(10, 0),
+          parsedVersion: new Version(10, 0),
+          version: '10.0',
           platform: 'Windows Phone',
-          platformVersion: new Version(8, 0),
+          parsedPlatformVersion: new Version(8, 0),
+          platformVersion: '8.0',
           engine: 'MSIE',
-          engineVersion: new Version(10, 0),
+          parsedEngineVersion: new Version(10, 0),
+          engineVersion: '10.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -545,11 +635,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; SAMSUNG; SGH-i917)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(9, 0),
+          parsedVersion: new Version(9, 0),
+          version: '9.0',
           platform: 'Windows Phone',
-          platformVersion: new Version(7, 5),
+          parsedPlatformVersion: new Version(7, 5),
+          platformVersion: '7.5',
           engine: 'MSIE',
-          engineVersion: new Version(9, 0),
+          parsedEngineVersion: new Version(9, 0),
+          engineVersion: '9.0',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -563,11 +656,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/4.0 (compatible; MSIE 5.23; Mac_PowerPC)'))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(5, 23),
+          parsedVersion: new Version(5, 23),
+          version: '5.23',
           platform: 'Macintosh',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'MSIE',
-          engineVersion: new Version(5, 23),
+          parsedEngineVersion: new Version(5, 23),
+          engineVersion: '5.23',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -577,15 +673,18 @@ describe('UserAgentParser', function () {
         });
       });
 
-      it('should detect Internet Explorer with Trident version', function () {
+      it('should detect Internet Explorer with Trident parsedVersion', function () {
         expect(parse('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; InfoPath.2)', { documentMode: 8 }))
         .toMatchUserAgent({
           name: 'MSIE',
-          version: new Version(8, 0),
+          parsedVersion: new Version(8, 0),
+          version: '8.0',
           platform: 'Windows',
-          platformVersion: new Version(6, 1),
+          parsedPlatformVersion: new Version(6, 1),
+          platformVersion: '6.1',
           engine: 'MSIE',
-          engineVersion: new Version(8, 0),
+          parsedEngineVersion: new Version(8, 0),
+          engineVersion: '8.0',
           documentMode: 8,
           browserInfo: {
             hasWebFontSupport: true,
@@ -601,11 +700,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 2.2.1; en-ca; LG-P505R Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Android',
-          platformVersion: new Version(2, 2, 1),
+          parsedPlatformVersion: new Version(2, 2, 1),
+          platformVersion: '2.2.1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(533, 1),
+          parsedEngineVersion: new Version(533, 1),
+          engineVersion: '533.1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -619,11 +721,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; Nexus One Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Android',
-          platformVersion: new Version(2, 1, null, 'update1'),
+          parsedPlatformVersion: new Version(2, 1, null, 'update1'),
+          platformVersion: '2.1-update1',
           engine: 'AppleWebKit',
-          engineVersion: new Version(530, 17),
+          parsedEngineVersion: new Version(530, 17),
+          engineVersion: '530.17',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -637,11 +742,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; Android 4.2.2; sl-si; SAMSUNG GT-I9505 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(18, 0, 1025, 308),
+          parsedVersion: new Version(18, 0, 1025, 308),
+          version: '18.0.1025.308',
           platform: 'Android',
-          platformVersion: new Version(4, 2, 2),
+          parsedPlatformVersion: new Version(4, 2, 2),
+          platformVersion: '4.2.2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -653,11 +761,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SGH-M919 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(18, 0, 1025, 308),
+          parsedVersion: new Version(18, 0, 1025, 308),
+          version: '18.0.1025.308',
           platform: 'Android',
-          platformVersion: new Version(4, 2, 2),
+          parsedPlatformVersion: new Version(4, 2, 2),
+          platformVersion: '4.2.2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -671,11 +782,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(11, 0, 696, 34),
+          parsedVersion: new Version(11, 0, 696, 34),
+          version: '11.0.696.34',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 24),
+          parsedEngineVersion: new Version(534, 24),
+          engineVersion: '534.24',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -689,11 +803,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; sdk Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Android',
-          platformVersion: new Version(4, 1, 2),
+          parsedPlatformVersion: new Version(4, 1, 2),
+          platformVersion: '4.1.2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 30),
+          parsedEngineVersion: new Version(534, 30),
+          engineVersion: '534.30',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -707,11 +824,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(11, 0, 696, 34),
+          parsedVersion: new Version(11, 0, 696, 34),
+          version: '11.0.696.34',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 24),
+          parsedEngineVersion: new Version(534, 24),
+          engineVersion: '534.24',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -725,11 +845,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Nexus S Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Android',
-          platformVersion: new Version(4, 1, 2),
+          parsedPlatformVersion: new Version(4, 1, 2),
+          platformVersion: '4.1.2',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 30),
+          parsedEngineVersion: new Version(534, 30),
+          engineVersion: '534.30',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -743,11 +866,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (BB10; Touch) AppleWebKit/537.3+ (KHTML, like Gecko) Version/10.0.9.388 Mobile Safari/537.3+'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'BlackBerry',
-          platformVersion: new Version(10, 0, 9, 388),
+          parsedPlatformVersion: new Version(10, 0, 9, 388),
+          platformVersion: '10.0.9.388',
           engine: 'AppleWebKit',
-          engineVersion: new Version(537, 3),
+          parsedEngineVersion: new Version(537, 3),
+          engineVersion: '537.3+',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -761,11 +887,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+'))
         .toMatchUserAgent({
           name: 'BuiltinBrowser',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'BlackBerry',
-          platformVersion: new Version(7, 1, 0, 346),
+          parsedPlatformVersion: new Version(7, 1, 0, 346),
+          platformVersion: '7.1.0.346',
           engine: 'AppleWebKit',
-          engineVersion: new Version(534, 11),
+          parsedEngineVersion: new Version(534, 11),
+          engineVersion: '534.11+',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -781,11 +910,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Mobile Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Android',
-          platformVersion: new Version(4, 0, 3),
+          parsedPlatformVersion: new Version(4, 0, 3),
+          platformVersion: '4.0.3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -799,11 +931,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; en-us; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -817,11 +952,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Mobile Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Android',
-          platformVersion: new Version(4, 0, 3),
+          parsedPlatformVersion: new Version(4, 0, 3),
+          platformVersion: '4.0.3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -835,11 +973,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; en-us; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -853,11 +994,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFJWI Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Mobile Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Android',
-          platformVersion: new Version(4, 0, 3),
+          parsedPlatformVersion: new Version(4, 0, 3),
+          platformVersion: '4.0.3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -871,11 +1015,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; en-us; KFJWI Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -889,11 +1036,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; KFJWA Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Mobile Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Android',
-          platformVersion: new Version(4, 0, 3),
+          parsedPlatformVersion: new Version(4, 0, 3),
+          platformVersion: '4.0.3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -907,11 +1057,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; en-us; KFJWA Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.6 Safari/535.19 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(2, 6),
+          parsedVersion: new Version(2, 6),
+          version: '2.6',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(535, 19),
+          parsedEngineVersion: new Version(535, 19),
+          engineVersion: '535.19',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -925,11 +1078,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Silk/1.0.22.79_10013310) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(1, 0, 22, '79_10013310'),
+          parsedVersion: new Version(1, 0, 22, '79_10013310'),
+          version: '1.0.22.79_10013310',
           platform: 'Android',
-          platformVersion: new Version(2, 3, 4),
+          parsedPlatformVersion: new Version(2, 3, 4),
+          platformVersion: '2.3.4',
           engine: 'AppleWebKit',
-          engineVersion: new Version(533, 1),
+          parsedEngineVersion: new Version(533, 1),
+          engineVersion: '533.1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -943,11 +1099,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.0.22.79_10013310) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=false'))
         .toMatchUserAgent({
           name: 'Silk',
-          version: new Version(1, 0, 22, '79_10013310'),
+          parsedVersion: new Version(1, 0, 22, '79_10013310'),
+          version: '1.0.22.79_10013310',
           platform: 'Macintosh',
-          platformVersion: new Version(10, 6, 3),
+          parsedPlatformVersion: new Version(10, 6, 3),
+          platformVersion: '10_6_3',
           engine: 'AppleWebKit',
-          engineVersion: new Version(533, 16),
+          parsedEngineVersion: new Version(533, 16),
+          engineVersion: '533.16',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -963,11 +1122,14 @@ describe('UserAgentParser', function () {
         expect(parse('Opera/9.80 (Linux i686; U; en) Presto/2.5.22 Version/10.51'))
         .toMatchUserAgent({
           name: 'Opera',
-          version: new Version(10, 51),
+          parsedVersion: new Version(10, 51),
+          version: '10.51',
           platform: 'Linux',
-          platformVersion: new Version(), //'i686'
+          parsedPlatformVersion: new Version(), //'i686'
+          platformVersion: 'Unknown',
           engine: 'Presto',
-          engineVersion: new Version(2, 5, 22),
+          parsedEngineVersion: new Version(2, 5, 22),
+          engineVersion: '2.5.22',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -981,10 +1143,13 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Linux i686 ; U; en; rv:1.8.1) Gecko/20061208 Firefox/2.0.0 Opera 9.70'))
         .toMatchUserAgent({
           name: 'Opera',
-          version: new Version(9, 70),
+          parsedVersion: new Version(9, 70),
+          version: '9.70',
           platform: 'Linux',
-          platformVersion: new Version(), //'i686'
+          parsedPlatformVersion: new Version(), //'i686'
+          platformVersion: 'Unknown',
           engine: 'Gecko',
+          parsedEngineVersion: new Version(1, 8, 1),
           engineVersion: '1.8.1',
           documentMode: undefined,
           browserInfo: {
@@ -999,11 +1164,14 @@ describe('UserAgentParser', function () {
         expect(parse('Opera/9.64 (X11; Linux i686; U; Linux Mint; nb) Presto/2.1.1'))
         .toMatchUserAgent({
           name: 'Opera',
-          version: new Version(9, 64),
+          parsedVersion: new Version(9, 64),
+          version: '9.64',
           platform: 'Linux',
-          platformVersion: new Version(), //'i686'
+          parsedPlatformVersion: new Version(), //'i686'
+          platformVersion: 'Unknown',
           engine: 'Presto',
-          engineVersion: new Version(2, 1, 1),
+          parsedEngineVersion: new Version(2, 1, 1),
+          engineVersion: '2.1.1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1017,11 +1185,14 @@ describe('UserAgentParser', function () {
         expect(parse('Opera/9.80 (Android 4.1.1; Linux; Opera Mobi/ADR-1207201819; U; en) Presto/2.10.254 Version/12.00'))
         .toMatchUserAgent({
           name: 'Opera',
-          version: new Version(12, 0),
+          parsedVersion: new Version(12, 0),
+          version: '12.00',
           platform: 'Android',
-          platformVersion: new Version(4, 1, 1),
+          parsedPlatformVersion: new Version(4, 1, 1),
+          platformVersion: '4.1.1',
           engine: 'Presto',
-          engineVersion: new Version(2, 10, 254),
+          parsedEngineVersion: new Version(2, 10, 254),
+          engineVersion: '2.10.254',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1035,11 +1206,14 @@ describe('UserAgentParser', function () {
         expect(parse('Opera/9.80 (Android; Opera Mini/7.0.29952/28.2144; U; en) Presto/2.8.119 Version/11.10'))
         .toMatchUserAgent({
           name: 'OperaMini',
-          version: new Version(7, 0, 29952),
+          parsedVersion: new Version(7, 0, 29952),
+          version: '7.0.29952',
           platform: 'Android',
+          parsedPlatformVersion: new Version(),
           platformVersion: 'Unknown',
           engine: 'Presto',
-          engineVersion: new Version(2, 8, 119),
+          parsedEngineVersion: new Version(2, 8, 119),
+          engineVersion: '2.8.119',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1055,11 +1229,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/536.5 (KHTML, like Gecko) Chrome/19.0.1084.9 Safari/536.5'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(19, 0, 1084, 9),
+          parsedVersion: new Version(19, 0, 1084, 9),
+          version: '19.0.1084.9',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(536, 5),
+          parsedEngineVersion: new Version(536, 5),
+          engineVersion: '536.5',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1073,11 +1250,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.814.2 Safari/536.11'))
         .toMatchUserAgent({
           name: 'Chrome',
-          version: new Version(20, 0, 814, 2),
+          parsedVersion: new Version(20, 0, 814, 2),
+          version: '20.0.814.2',
           platform: 'Linux',
-          platformVersion: new Version(),
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
           engine: 'AppleWebKit',
-          engineVersion: new Version(536, 11),
+          parsedEngineVersion: new Version(536, 11),
+          engineVersion: '536.11',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1093,11 +1273,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:1.9.1.4) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(1, 9, 1, 4),
+          parsedEngineVersion: new Version(1, 9, 1, 4),
+          engineVersion: '1.9.1.4',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1107,15 +1290,18 @@ describe('UserAgentParser', function () {
         });
       });
 
-      it('should detect unknown versions of Gecko as supporting web fonts', function () {
+      it('should detect unknown parsedVersions of Gecko as supporting web fonts', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:2.5.8) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(2, 5, 8),
+          parsedEngineVersion: new Version(2, 5, 8),
+          engineVersion: '2.5.8',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1129,11 +1315,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:1.10.1b) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(1, 10, 1, 'b'),
+          parsedEngineVersion: new Version(1, 10, 1, 'b'),
+          engineVersion: '1.10.1b',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: true,
@@ -1143,15 +1332,18 @@ describe('UserAgentParser', function () {
         });
       });
 
-      it('should detect Gecko with an invalid version number as not supporting web fonts', function () {
+      it('should detect Gecko with an invalid parsedVersion number as not supporting web fonts', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:1.b) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(1, null, null, 'b'),
+          parsedEngineVersion: new Version(1, null, null, 'b'),
+          engineVersion: '1.b',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1163,11 +1355,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:1.b) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(1, null, null, 'b'),
+          parsedEngineVersion: new Version(1, null, null, 'b'),
+          engineVersion: '1.b',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1179,11 +1374,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:1.9) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(1, 9),
+          parsedEngineVersion: new Version(1, 9),
+          engineVersion: '1.9',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1195,11 +1393,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:0.10.1) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(0, 10, 1),
+          parsedEngineVersion: new Version(0, 10, 1),
+          engineVersion: '0.10.1',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,
@@ -1211,11 +1412,14 @@ describe('UserAgentParser', function () {
         expect(parse('Mozilla/5.0 (Windows; U; Windows NT 5.1; ru-RU; rv:0.3.42) Gecko/20091016 (.NET CLR 3.5.30729)'))
         .toMatchUserAgent({
           name: 'Mozilla',
-          version: new Version(),
+          parsedVersion: new Version(),
+          version: 'Unknown',
           platform: 'Windows',
-          platformVersion: new Version(5, 1),
+          parsedPlatformVersion: new Version(5, 1),
+          platformVersion: '5.1',
           engine: 'Gecko',
-          engineVersion: new Version(0, 3, 42),
+          parsedEngineVersion: new Version(0, 3, 42),
+          engineVersion: '0.3.42',
           documentMode: undefined,
           browserInfo: {
             hasWebFontSupport: false,

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -310,16 +310,17 @@ goog.scope(function () {
     }
 
     if (browserName == UserAgentParser.BUILTIN_BROWSER) {
-      browserVersion = new Version();
+      browserVersionString = UserAgentParser.UNKNOWN;
     } else if (browserName == "Silk") {
-      browserVersion = Version.parse(this.getMatchingGroup_(this.userAgent_, /Silk\/([\d\._]+)/, 1));
+      browserVersionString = this.getMatchingGroup_(this.userAgent_, /Silk\/([\d\._]+)/, 1);
     } else if (browserName == "Chrome") {
-      browserVersion = Version.parse(this.getMatchingGroup_(this.userAgent_, /(Chrome|CrMo|CriOS)\/([\d\.]+)/, 2));
+      browserVersionString = this.getMatchingGroup_(this.userAgent_, /(Chrome|CrMo|CriOS)\/([\d\.]+)/, 2);
     } else if (this.userAgent_.indexOf("Version/") != -1) {
-      browserVersion = Version.parse(this.getMatchingGroup_(this.userAgent_, /Version\/([\d\.\w]+)/, 1));
+      browserVersionString = this.getMatchingGroup_(this.userAgent_, /Version\/([\d\.\w]+)/, 1);
     } else if (browserName == "AdobeAIR") {
-      browserVersion = Version.parse(this.getMatchingGroup_(this.userAgent_, /AdobeAIR\/([\d\.]+)/, 1));
+      browserVersionString = this.getMatchingGroup_(this.userAgent_, /AdobeAIR\/([\d\.]+)/, 1);
     }
+    browserVersion = Version.parse(browserVersionString);
 
     if (browserName == "AdobeAIR") {
       supportWebFont = browserVersion.major > 2 || browserVersion.major == 2 && browserVersion.minor >= 5;


### PR DESCRIPTION
- Fixes an issue with the tests where the UA Jasmine matcher hadn't been updated to check both parsed versions and string versions.
- Fixes a problem with the UA parser where we forgot to set the old string browser version for Chrome alongside the parsed version. This causes fonts not to load on Chrome for old Typekit kits when loaded through WFL.
