### PR TITLE
Add support for PhantomJS

### DIFF
--- a/spec/core/useragentparser_spec.js
+++ b/spec/core/useragentparser_spec.js
@@ -1429,5 +1429,28 @@ describe('UserAgentParser', function () {
         });
       });
     });
+
+    describe('PhantomJS', function () {
+      it('should detect PhantomJS as having web font support', function () {
+        expect(parse('Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/534.34 (KHTML, like Gecko) PhantomJS/1.9.0 (development) Safari/534.34'))
+        .toMatchUserAgent({
+          name: 'PhantomJS',
+          parsedVersion: new Version(1, 9, 0),
+          version: '1.9.0',
+          platform: 'Macintosh',
+          parsedPlatformVersion: new Version(),
+          platformVersion: 'Unknown',
+          engine: 'AppleWebKit',
+          parsedEngineVersion: new Version(534, 34),
+          engineVersion: '534.34',
+          documentMode: undefined,
+          browserInfo: {
+            hasWebFontSupport: true,
+            hasWebKitFallbackBug: true,
+            hasWebKitMetricsBug: true
+          }
+        });
+      });
+    });
   });
 });

--- a/src/core/useragentparser.js
+++ b/src/core/useragentparser.js
@@ -303,6 +303,8 @@ goog.scope(function () {
       browserName = "Silk";
     } else if (platform == "BlackBerry" || platform == "Android") {
       browserName = UserAgentParser.BUILTIN_BROWSER;
+    } else if (this.userAgent_.indexOf("PhantomJS") != -1) {
+      browserName = "PhantomJS";
     } else if (this.userAgent_.indexOf("Safari") != -1) {
       browserName = "Safari";
     } else if (this.userAgent_.indexOf("AdobeAIR") != -1) {
@@ -319,6 +321,8 @@ goog.scope(function () {
       browserVersionString = this.getMatchingGroup_(this.userAgent_, /Version\/([\d\.\w]+)/, 1);
     } else if (browserName == "AdobeAIR") {
       browserVersionString = this.getMatchingGroup_(this.userAgent_, /AdobeAIR\/([\d\.]+)/, 1);
+    } else if (browserName == "PhantomJS") {
+      browserVersionString = this.getMatchingGroup_(this.userAgent_, /PhantomJS\/([\d.]+)/, 1);
     }
     browserVersion = Version.parse(browserVersionString);
 


### PR DESCRIPTION
_Needs review._ This pull request adds support for recognizing the PhantomJS user agent string correctly. While this isn't strictly necessary, it makes headless testing easier by not having to set a custom user agent string.
