### PR TITLE
Do not use the terminal reporter when not in PhantomJS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -68,7 +68,9 @@
               color: true
             });
 
-        env.addReporter(terminalReporter);
+        if (/PhantomJS/.test(navigator.userAgent)) {
+          env.addReporter(terminalReporter);
+        }
         env.addReporter(htmlReporter);
         env.specFilter = function (spec) {
           return htmlReporter.specFilter(spec);


### PR DESCRIPTION
_Ready to deploy._ Only enable the terminal reporter when we detect PhantomJS. This stops the console from being spammed with terminal output.
