### PR TITLE
Change fast.fonts.com to fast.fonts.net

### DIFF
--- a/spec/modules/monotype_spec.js
+++ b/spec/modules/monotype_spec.js
@@ -7,7 +7,7 @@ describe('modules.Monotype', function () {
 
   var configuration = {
     projectId: '01e2ff27-25bf-4801-a23e-73d328e6c7cc',
-    api: 'http://fast.fonts.com/jsapidev'
+    api: 'http://fast.fonts.net/jsapidev'
   };
 
   var fakeDomHelper = null,
@@ -60,7 +60,7 @@ describe('modules.Monotype', function () {
   it('should create a script element', function () {
     expect(support).toHaveBeenCalled();
     expect(fakeDomHelper.loadScript).toHaveBeenCalled();
-    expect(fakeDomHelper.loadScript.calls[0].args[0]).toEqual('http://fast.fonts.com/jsapidev/01e2ff27-25bf-4801-a23e-73d328e6c7cc.js');
+    expect(fakeDomHelper.loadScript.calls[0].args[0]).toEqual('http://fast.fonts.net/jsapidev/01e2ff27-25bf-4801-a23e-73d328e6c7cc.js');
     expect(load).toHaveBeenCalledWith([new Font('aachen bold'), new Font('kid print regular')]);
   });
 });

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -79,7 +79,7 @@ goog.scope(function () {
 
   Monotype.prototype.getScriptSrc = function (projectId, version) {
     var p = this.domHelper_.getProtocol();
-    var api = (this.configuration_['api'] || 'fast.fonts.com/jsapi').replace(/^.*http(s?):(\/\/)?/, "");
+    var api = (this.configuration_['api'] || 'fast.fonts.net/jsapi').replace(/^.*http(s?):(\/\/)?/, "");
     return p + "//" + api + '/' + projectId + '.js' + ( version ? '?v='+ version : '' );
   };
 


### PR DESCRIPTION
Hi,

We have changed fast.fonts.com to fast.fonts.net. The domain fast.fonts.net is cookie-less hence would require less bandwidth to transfer resources.
