### PR TITLE
Update README to explain custom font options without specifying a stylesheet URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In this example, the `fonts.css` file might look something like this:
       src: ...;
     }
 
-Alternatively, you can load your fonts from a stylesheet not specified in WebFontConfig. As long as the names match those that are declared in the `families` array, the proper loading classes will be applied to the <html> element.
+Alternatively, you can load your fonts from a stylesheet not specified in WebFontConfig. As long as the names match those that are declared in the `families` array, the proper loading classes will be applied to the html element.
 
 ```
 <script src="//ajax.googleapis.com/ajax/libs/webfont/1.4.7/webfont.js"></script>
@@ -195,7 +195,7 @@ Alternatively, you can load your fonts from a stylesheet not specified in WebFon
 <style type="text/css">
    @font-face {
       font-family:"My Font";
-      url("assets/fonts/my_font.woff") format("woff")
+      src:url("assets/fonts/my_font.woff") format("woff");
    }
 </style>
 ```


### PR DESCRIPTION
If you are choosing to go with "custom" fonts (not from a service like TypeKit or Fonts.com), you do not have to specify the stylesheet URL in WebFontConfig. You can load them however you choose, and as long as the names match the proper classes will be applied.
