### PR TITLE
Add display:block to FontRuler so it can not be easily overridden.

### DIFF
--- a/src/core/fontruler.js
+++ b/src/core/fontruler.js
@@ -38,7 +38,7 @@ goog.scope(function () {
    * @return {string}
    */
   FontRuler.prototype.computeStyleString_ = function(font) {
-    return "position:absolute;top:-999px;left:-999px;" +
+    return "display:block;position:absolute;top:-999px;left:-999px;" +
            "font-size:300px;width:auto;height:auto;line-height:normal;margin:0;" +
            "padding:0;font-variant:normal;white-space:nowrap;font-family:" +
            font.getCssName() + ";" + font.getCssVariation();


### PR DESCRIPTION
_Needs review._ This PR is to prevent people from accidentally setting `display: none` on our font load detection spans. This has happened in a few instances with global selectors.
