### PR TITLE
Do not start font watching if all modules failed to load.

### DIFF
--- a/spec/core/webfont_spec.js
+++ b/spec/core/webfont_spec.js
@@ -264,6 +264,7 @@ describe('WebFont', function () {
       });
 
       expect(inactive).toHaveBeenCalled();
+      expect(inactive.calls.length).toEqual(1);
     });
   });
 

--- a/src/core/webfont.js
+++ b/src/core/webfont.js
@@ -68,8 +68,9 @@ goog.scope(function () {
 
       if (allModulesLoaded && this.moduleFailedLoading_ == 0) {
         eventDispatcher.dispatchInactive();
+      } else {
+        fontWatcher.watchFonts([], {}, null, allModulesLoaded);
       }
-      fontWatcher.watchFonts([], {}, null, allModulesLoaded);
     }
   };
 


### PR DESCRIPTION
_Needs review._ This fixes a bug where the `inactive` event is fired twice if all modules fail to load. This was reported in #193.
