### PR TITLE
Reduce font load timeout

### DIFF
--- a/src/core/fontwatchrunner.js
+++ b/src/core/fontwatchrunner.js
@@ -23,7 +23,7 @@ webfont.FontWatchRunner = function(activeCallback, inactiveCallback, domHelper,
   this.fontTestString_ = opt_fontTestString || webfont.FontWatchRunner.DEFAULT_TEST_STRING;
   this.browserInfo_ = browserInfo;
   this.lastResortWidths_ = {};
-  this.timeout_ = opt_timeout || 5000;
+  this.timeout_ = opt_timeout || 3000;
 
   this.metricCompatibleFonts_ = opt_metricCompatibleFonts || null;
 


### PR DESCRIPTION
_Needs review._ This reduces the font load timeout from 5 seconds to 3. This is more in line with browsers that show the fallback text after 3 seconds.
