### PR TITLE
Record font ruler width in a separate loop to avoid unnecessary reflows

### DIFF
--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -52,7 +52,8 @@ goog.scope(function () {
       this.last_ = last;
     }
 
-    for (var i = 0; i < fonts.length; i++) {
+    var i, fontWatchRunners = [];
+    for (i = 0; i < fonts.length; i++) {
       var font = fonts[i],
           testString = testStrings[font.getName()];
 
@@ -92,7 +93,11 @@ goog.scope(function () {
         testString
       );
 
-      fontWatchRunner.start();
+      fontWatchRunners.push(fontWatchRunner);
+    }
+
+    for (i = 0; i < fontWatchRunners.length; i++) {
+      fontWatchRunners[i].start();
     }
   };
 

--- a/src/core/fontwatchrunner.js
+++ b/src/core/fontwatchrunner.js
@@ -101,13 +101,13 @@ goog.scope(function () {
     this.fontRulerA_.insert();
     this.fontRulerB_.insert();
     this.fontRulerC_.insert();
-
-    this.lastResortWidths_[FontWatchRunner.LastResortFonts.SERIF] = this.fontRulerA_.getWidth();
-    this.lastResortWidths_[FontWatchRunner.LastResortFonts.SANS_SERIF] = this.fontRulerB_.getWidth();
-    this.lastResortWidths_[FontWatchRunner.LastResortFonts.MONOSPACE] = this.fontRulerC_.getWidth();
   };
 
   FontWatchRunner.prototype.start = function() {
+    this.lastResortWidths_[FontWatchRunner.LastResortFonts.SERIF] = this.fontRulerA_.getWidth();
+    this.lastResortWidths_[FontWatchRunner.LastResortFonts.SANS_SERIF] = this.fontRulerB_.getWidth();
+    this.lastResortWidths_[FontWatchRunner.LastResortFonts.MONOSPACE] = this.fontRulerC_.getWidth();
+
     this.started_ = goog.now();
 
     this.fontRulerA_.setFont(new Font(this.font_.getName() + ',' + FontWatchRunner.LastResortFonts.SERIF, this.font_.getVariation()));


### PR DESCRIPTION
This change reduces the font loader overhead by reducing the number of reflows when multiple font files have to be loaded.