### PR TITLE
Remove font rulers and trigger callback asychronously to avoid unnecssary reflows

### DIFF
--- a/src/core/fontwatchrunner.js
+++ b/src/core/fontwatchrunner.js
@@ -235,10 +235,15 @@ goog.scope(function () {
    * @param {function(webfont.Font)} callback
    */
   FontWatchRunner.prototype.finish_ = function(callback) {
-    this.fontRulerA_.remove();
-    this.fontRulerB_.remove();
-    this.lastResortRulerA_.remove();
-    this.lastResortRulerB_.remove();
-    callback(this.font_);
+    // Remove elements and trigger callback (which adds active/inactive class) asynchronously to avoid reflow chain if
+    // several fonts are finished loading right after each other
+    setTimeout(goog.bind(function () {
+      this.fontRulerA_.remove();
+      this.fontRulerB_.remove();
+      this.lastResortRulerA_.remove();
+      this.lastResortRulerB_.remove();
+      callback(this.font_);
+    }, this), 0);
   };
+
 });


### PR DESCRIPTION
If the fonts are cached, the `finish_` function is called for all fonts right after each other. The problem with that is that removing the font ruler elements and changing the classes in the callback marks the dom as dirty and then the next `check_` call causes a reflow (because it reads offsetWidth). Using `setTimeout` is the simplest solution to avoid this.

An alternative would be to remove all font ruler elements in `decreaseCurrentlyWatched_`, but this wouldn't solve the class (-active/-inactive) issue.