### PR TITLE
Re-enable NativeFontWatchRunner

### DIFF
--- a/spec/core/fontwatcher_spec.js
+++ b/spec/core/fontwatcher_spec.js
@@ -1,6 +1,7 @@
 describe('FontWatcher', function () {
   var FontWatcher = webfont.FontWatcher,
       FontWatchRunner = webfont.FontWatchRunner,
+      NativeFontWatchRunner = webfont.NativeFontWatchRunner,
       Font = webfont.Font,
       DomHelper = webfont.DomHelper,
       Version = webfont.Version,
@@ -29,7 +30,7 @@ describe('FontWatcher', function () {
     eventDispatcher.dispatchActive = jasmine.createSpy('dispatchActive');
     eventDispatcher.dispatchInactive = jasmine.createSpy('dispatchInactive');
 
-    spyOn(FontWatchRunner.prototype, 'start').andCallFake(function (font, fontTestString) {
+    var fakeStart = function (font, fontTestString) {
       var found = false;
 
       testStrings(this.fontTestString_);
@@ -47,7 +48,10 @@ describe('FontWatcher', function () {
       } else {
         this.inactiveCallback_(this.font_);
       }
-    });
+    };
+
+    spyOn(FontWatchRunner.prototype, 'start').andCallFake(fakeStart);
+    spyOn(NativeFontWatchRunner.prototype, 'start').andCallFake(fakeStart);
   });
 
   describe('watch zero fonts', function () {
@@ -196,6 +200,7 @@ describe('FontWatcher', function () {
     it('should use the correct tests strings', function () {
       activeFonts = [font1, font2];
 
+      var defaultTestString = FontWatcher.shouldUseNativeLoader ? undefined : FontWatchRunner.DEFAULT_TEST_STRING;
       var fontWatcher = new FontWatcher(domHelper, eventDispatcher);
 
       fontWatcher.watchFonts([font1, font2, font3, font4], {
@@ -207,9 +212,9 @@ describe('FontWatcher', function () {
 
       expect(testStrings.callCount).toEqual(4);
       expect(testStrings.calls[0].args[0]).toEqual('testString1');
-      expect(testStrings.calls[1].args[0]).toEqual(FontWatchRunner.DEFAULT_TEST_STRING);
+      expect(testStrings.calls[1].args[0]).toEqual(defaultTestString);
       expect(testStrings.calls[2].args[0]).toEqual('testString2');
-      expect(testStrings.calls[3].args[0]).toEqual(FontWatchRunner.DEFAULT_TEST_STRING);
+      expect(testStrings.calls[3].args[0]).toEqual(defaultTestString);
     });
   });
 

--- a/spec/deps.js
+++ b/spec/deps.js
@@ -2,6 +2,7 @@
 goog.addDependency("../../src/closure.js", [], []);
 goog.addDependency("../../src/core/cssclassname.js", ["webfont.CssClassName"], []);
 goog.addDependency("../../src/core/domhelper.js", ["webfont.DomHelper"], []);
+goog.addDependency("../../src/core/stylesheetwaiter.js", ["webfont.StyleSheetWaiter"], []);
 goog.addDependency("../../src/core/eventdispatcher.js", ["webfont.EventDispatcher"], ["webfont.CssClassName"]);
 goog.addDependency("../../src/core/font.js", ["webfont.Font"], []);
 goog.addDependency("../../src/core/fontmodule.js", ["webfont.FontModule"], []);
@@ -12,10 +13,10 @@ goog.addDependency("../../src/core/fontwatchrunner.js", ["webfont.FontWatchRunne
 goog.addDependency("../../src/core/initialize.js", ["webfont"], ["webfont.WebFont","webfont.modules.Typekit","webfont.modules.Fontdeck","webfont.modules.Monotype","webfont.modules.Custom","webfont.modules.google.GoogleFontApi"]);
 goog.addDependency("../../src/core/nativefontwatchrunner.js", ["webfont.NativeFontWatchRunner"], ["webfont.Font"]);
 goog.addDependency("../../src/core/webfont.js", ["webfont.WebFont"], ["webfont.DomHelper","webfont.EventDispatcher","webfont.FontWatcher","webfont.FontModuleLoader"]);
-goog.addDependency("../../src/modules/custom.js", ["webfont.modules.Custom"], ["webfont.Font"]);
+goog.addDependency("../../src/modules/custom.js", ["webfont.modules.Custom"], ["webfont.Font", "webfont.StyleSheetWaiter"]);
 goog.addDependency("../../src/modules/fontdeck.js", ["webfont.modules.Fontdeck"], ["webfont.Font"]);
 goog.addDependency("../../src/modules/google/fontapiparser.js", ["webfont.modules.google.FontApiParser"], ["webfont.Font"]);
 goog.addDependency("../../src/modules/google/fontapiurlbuilder.js", ["webfont.modules.google.FontApiUrlBuilder"], []);
-goog.addDependency("../../src/modules/google/googlefontapi.js", ["webfont.modules.google.GoogleFontApi"], ["webfont.modules.google.FontApiUrlBuilder","webfont.modules.google.FontApiParser","webfont.FontWatchRunner"]);
+goog.addDependency("../../src/modules/google/googlefontapi.js", ["webfont.modules.google.GoogleFontApi"], ["webfont.modules.google.FontApiUrlBuilder","webfont.modules.google.FontApiParser","webfont.FontWatchRunner", "webfont.StyleSheetWaiter"]);
 goog.addDependency("../../src/modules/monotype.js", ["webfont.modules.Monotype"], ["webfont.Font"]);
 goog.addDependency("../../src/modules/typekit.js", ["webfont.modules.Typekit"], ["webfont.Font"]);

--- a/spec/modules/custom_spec.js
+++ b/spec/modules/custom_spec.js
@@ -1,10 +1,19 @@
 describe('modules.Custom', function () {
   var Custom = webfont.modules.Custom,
-      FontFamily = webfont.FontFamily;
+      FontFamily = webfont.FontFamily,
+      Any = jasmine.Matchers.Any;
 
   describe('insert links correctly', function () {
     var fakeDomHelper = null,
         load = null;
+
+    function notiySheetsLoaded() {
+      var argsForCall = fakeDomHelper.loadStylesheet.argsForCall;
+      for (var i = 0; i < argsForCall.length; i++) {
+        var args = argsForCall[i];
+        args[1]();
+      }
+    }
 
     beforeEach(function () {
       fakeDomHelper = {
@@ -26,11 +35,20 @@ describe('modules.Custom', function () {
 
     it('should have inserted the links correctly', function () {
       expect(fakeDomHelper.loadStylesheet.callCount).toEqual(2);
-      expect(fakeDomHelper.loadStylesheet).toHaveBeenCalledWith('http://moo');
-      expect(fakeDomHelper.loadStylesheet).toHaveBeenCalledWith('http://meuh');
+      expect(fakeDomHelper.loadStylesheet).toHaveBeenCalledWith('http://moo', new Any(Function));
+      expect(fakeDomHelper.loadStylesheet).toHaveBeenCalledWith('http://meuh', new Any(Function));
     });
 
+    if (webfont.StyleSheetWaiter.shouldWait) {
+      it('should not invoke callback before all CSS are loaded', function () {
+        expect(load.callCount).toEqual(0);
+        notiySheetsLoaded();
+        expect(load.callCount).toEqual(1);
+      });
+    }
+
     it('should have loaded the families correctly', function () {
+      notiySheetsLoaded();
       expect(load.callCount).toEqual(1);
       expect(load.calls[0].args[0].length).toEqual(3);
       expect(load.calls[0].args[0][0].getName()).toEqual('Font1');
@@ -39,8 +57,10 @@ describe('modules.Custom', function () {
     });
 
     it('should have set a custom test string', function () {
+      notiySheetsLoaded();
       expect(load.callCount).toEqual(1);
       expect(load.calls[0].args[1]).toEqual({ Font3: 'hello world' });
     });
   });
+
 });

--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -66,37 +66,26 @@ goog.scope(function () {
 
       var fontWatchRunner = null;
 
-      // We've disabled the native font watch runner for now. The
-      // reason is that its behaviour is slightly different from
-      // the non-native version in that it returns immediately if
-      // a @font-face rule is not in the document. The non-native
-      // version keeps polling the page. A lot of modules depend
-      // on the ability to start font watching before actually
-      // loading the fonts, so they fail in this case (which is
-      // related to browser support; figuring out when a
-      // stylesheet has loaded reliably). Until that issue is
-      // resolved we'll keep the native font disabled.
-      //
-      //if (window['FontFace']) {
-      //  fontWatchRunner = new NativeFontWatchRunner(
-      //      goog.bind(this.fontActive_, this),
-      //      goog.bind(this.fontInactive_, this),
-      //      this.domHelper_,
-      //      font,
-      //      this.timeout_,
-      //      fontTestString
-      //    );
-      //} else {
-      //
-      fontWatchRunner = new FontWatchRunner(
-        goog.bind(this.fontActive_, this),
-        goog.bind(this.fontInactive_, this),
-        this.domHelper_,
-        font,
-        this.timeout_,
-        metricCompatibleFonts,
-        testString
-      );
+      if (FontWatcher.shouldUseNativeLoader) {
+        fontWatchRunner = new NativeFontWatchRunner(
+            goog.bind(this.fontActive_, this),
+            goog.bind(this.fontInactive_, this),
+            this.domHelper_,
+            font,
+            this.timeout_,
+            testString
+          );
+      } else {
+        fontWatchRunner = new FontWatchRunner(
+          goog.bind(this.fontActive_, this),
+          goog.bind(this.fontInactive_, this),
+          this.domHelper_,
+          font,
+          this.timeout_,
+          metricCompatibleFonts,
+          testString
+        );
+      }
 
       fontWatchRunners.push(fontWatchRunner);
     }

--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -29,6 +29,11 @@ goog.scope(function () {
       NativeFontWatchRunner = webfont.NativeFontWatchRunner;
 
   /**
+   * @const @type {boolean}
+   */
+  FontWatcher.shouldUseNativeLoader = !!window['FontFace'];
+
+  /**
    * Watches a set of font families.
    * @param {Array.<webfont.Font>} fonts The fonts to watch.
    * @param {webfont.FontTestStrings} fontTestStrings The font test strings for

--- a/src/core/stylesheetwaiter.js
+++ b/src/core/stylesheetwaiter.js
@@ -1,0 +1,48 @@
+goog.provide('webfont.StyleSheetWaiter');
+
+/**
+ * A utility class for handling callback from DomHelper.loadStylesheet().
+ *
+ * @constructor
+ */
+webfont.StyleSheetWaiter = function() {
+  /** @private @type {number} */
+  this.waitingCount_ = 0;
+  /** @private @type {Function} */
+  this.onReady_ = null;
+};
+
+goog.scope(function () {
+  var StyleSheetWaiter = webfont.StyleSheetWaiter;
+
+  /**
+   * @return {function(Error)}
+   */
+  StyleSheetWaiter.prototype.startWaitingLoad = function() {
+    var self = this;
+    self.waitingCount_++;
+    return function(error) {
+      self.waitingCount_--;
+      self.fireIfReady_();
+    };
+  };
+
+  /**
+   * @param {Function} fn
+   */
+  StyleSheetWaiter.prototype.waitWhileNeededThen = function(fn) {
+    this.onReady_ = fn;
+    this.fireIfReady_();
+  };
+
+  /**
+   * @private
+   */
+  StyleSheetWaiter.prototype.fireIfReady_ = function() {
+    var isReady = 0 == this.waitingCount_;
+    if (isReady && this.onReady_) {
+      this.onReady_();
+      this.onReady_ = null;
+    }
+  };
+});

--- a/src/modules.yml
+++ b/src/modules.yml
@@ -1,6 +1,7 @@
 core:
   - ../tools/compiler/base.js
   - core/domhelper.js
+  - core/stylesheetwaiter.js
   - core/cssclassname.js
   - core/font.js
   - core/eventdispatcher.js

--- a/src/modules/custom.js
+++ b/src/modules/custom.js
@@ -1,6 +1,7 @@
 goog.provide('webfont.modules.Custom');
 
 goog.require('webfont.Font');
+goog.require('webfont.StyleSheetWaiter');
 
 /**
  *
@@ -26,16 +27,17 @@ webfont.modules.Custom.NAME = 'custom';
 
 goog.scope(function () {
   var Custom = webfont.modules.Custom,
-      Font = webfont.Font;
+      Font = webfont.Font,
+      StyleSheetWaiter = webfont.StyleSheetWaiter;
 
   Custom.prototype.load = function(onReady) {
     var i, len;
     var urls = this.configuration_['urls'] || [];
     var familiesConfiguration = this.configuration_['families'] || [];
     var fontTestStrings = this.configuration_['testStrings'] || {};
-
+    var waiter = new StyleSheetWaiter();
     for (i = 0, len = urls.length; i < len; i++) {
-      this.domHelper_.loadStylesheet(urls[i]);
+      this.domHelper_.loadStylesheet(urls[i], waiter.startWaitingLoad());
     }
 
     var fonts = [];
@@ -54,6 +56,8 @@ goog.scope(function () {
       }
     }
 
-    onReady(fonts, fontTestStrings);
+    waiter.waitWhileNeededThen(function() {
+      onReady(fonts, fontTestStrings);
+    });
   };
 });

--- a/src/modules/google/googlefontapi.js
+++ b/src/modules/google/googlefontapi.js
@@ -3,6 +3,7 @@ goog.provide('webfont.modules.google.GoogleFontApi');
 goog.require('webfont.modules.google.FontApiUrlBuilder');
 goog.require('webfont.modules.google.FontApiParser');
 goog.require('webfont.FontWatchRunner');
+goog.require('webfont.StyleSheetWaiter');
 
 /**
  * @constructor
@@ -22,6 +23,7 @@ webfont.modules.google.GoogleFontApi.NAME = 'google';
 goog.scope(function () {
   var GoogleFontApi = webfont.modules.google.GoogleFontApi,
       FontWatchRunner = webfont.FontWatchRunner,
+      StyleSheetWaiter = webfont.StyleSheetWaiter,
       FontApiUrlBuilder = webfont.modules.google.FontApiUrlBuilder,
       FontApiParser = webfont.modules.google.FontApiParser;
 
@@ -32,6 +34,7 @@ goog.scope(function () {
   };
 
   GoogleFontApi.prototype.load = function(onReady) {
+    var waiter = new StyleSheetWaiter();
     var domHelper = this.domHelper_;
     var fontApiUrlBuilder = new FontApiUrlBuilder(
         this.configuration_['api'],
@@ -44,7 +47,9 @@ goog.scope(function () {
     var fontApiParser = new FontApiParser(fontFamilies);
     fontApiParser.parse();
 
-    domHelper.loadStylesheet(fontApiUrlBuilder.build());
-    onReady(fontApiParser.getFonts(), fontApiParser.getFontTestStrings(), GoogleFontApi.METRICS_COMPATIBLE_FONTS);
+    domHelper.loadStylesheet(fontApiUrlBuilder.build(), waiter.startWaitingLoad());
+    waiter.waitWhileNeededThen(function() {
+      onReady(fontApiParser.getFonts(), fontApiParser.getFontTestStrings(), GoogleFontApi.METRICS_COMPATIBLE_FONTS);
+    });
   };
 });


### PR DESCRIPTION
This is another attempt following #260 which enables NativeFontWatchRunner.

This change hooks into DomHelper so that NativeFontWatchRunner can wait till all requested stylesheets being loaded.
