### PR TITLE
Pass font variation with font-family

### DIFF
--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -68,7 +68,7 @@ goog.scope(function() {
             //Check if font-style and font-weight is available
             if (mti_fnts[i]["fontStyle"] != undefined && mti_fnts[i]["fontWeight"] != undefined) {
               fntVariation = mti_fnts[i]["fontStyle"] + mti_fnts[i]["fontWeight"];
-              fonts.push(new Font(fnt,fntVariation));
+              fonts.push(new Font(fnt, fntVariation));
             } else {
               fonts.push(new Font(fnt));
             }

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -58,11 +58,20 @@ goog.scope(function() {
     function checkAndLoadIfDownloaded() {
       if (loadWindow[Monotype.HOOK + projectId]) {
         var mti_fnts = loadWindow[Monotype.HOOK + projectId](),
-            fonts = [];
+            fonts = [],
+            fntVariation;
 
         if (mti_fnts) {
           for (var i = 0; i < mti_fnts.length; i++) {
-            fonts.push(new Font(mti_fnts[i]["fontfamily"]));
+            var fnt=mti_fnts[i]["fontfamily"];
+            
+            //Check if font-style and font-weight is available
+            if(mti_fnts[i]["fontStyle"]!=undefined && mti_fnts[i]["fontWeight"]!=undefined) {
+              fntVariation=mti_fnts[i]["fontStyle"]+mti_fnts[i]["fontWeight"];
+              fonts.push(new Font(fnt,fntVariation));
+            } else {
+              fonts.push(new Font(fnt));
+            }
           }
         }
         onReady(fonts);

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -4,9 +4,9 @@ goog.require('webfont.Font');
 
 /**
 webfont.load({
-monotype: {
-projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'//this is your Fonts.com Web fonts projectId
-}
+  monotype: {
+    projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'//this is your Fonts.com Web fonts projectId
+  }
 });
 */
 
@@ -14,7 +14,7 @@ projectId: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'//this is your Fonts.com Web fo
  * @constructor
  * @implements {webfont.FontModule}
  */
-webfont.modules.Monotype = function (domHelper, configuration) {
+webfont.modules.Monotype = function(domHelper, configuration) {
   this.domHelper_ = domHelper;
   this.configuration_ = configuration;
 };
@@ -40,48 +40,49 @@ webfont.modules.Monotype.HOOK = '__mti_fntLst';
  */
 webfont.modules.Monotype.SCRIPTID = '__MonotypeAPIScript__';
 
-goog.scope(function () {
+goog.scope(function() {
   var Monotype = webfont.modules.Monotype,
-      Font = webfont.Font;
+    Font = webfont.Font;
 
-  Monotype.prototype.getScriptSrc = function (projectId, version) {
+  Monotype.prototype.getScriptSrc = function(projectId, version) {
     var p = this.domHelper_.getProtocol();
     var api = (this.configuration_['api'] || 'fast.fonts.net/jsapi').replace(/^.*http(s?):(\/\/)?/, "");
-    return p + "//" + api + '/' + projectId + '.js' + ( version ? '?v='+ version : '' );
+    return p + "//" + api + '/' + projectId + '.js' + (version ? '?v=' + version : '');
   };
 
-  Monotype.prototype.load = function (onReady) {
+  Monotype.prototype.load = function(onReady) {
     var self = this;
     var projectId = self.configuration_['projectId'];
     var version = self.configuration_['version'];
-    function checkAndLoadIfDownloaded() {
-	  if (loadWindow[Monotype.HOOK + projectId]) {
-	    var mti_fnts = loadWindow[Monotype.HOOK + projectId](),
-	    fonts = [];
 
-	    if (mti_fnts) {
-		  for (var i = 0; i < mti_fnts.length; i++) {
-		    fonts.push(new Font(mti_fnts[i]["fontfamily"]));
-		  }
-	    }
-	    onReady(fonts);
-	  } else {
-	    setTimeout(function () {
-	      checkAndLoadIfDownloaded();
-	    }, 50);
-	  }
+    function checkAndLoadIfDownloaded() {
+      if (loadWindow[Monotype.HOOK + projectId]) {
+        var mti_fnts = loadWindow[Monotype.HOOK + projectId](),
+          fonts = [];
+
+        if (mti_fnts) {
+          for (var i = 0; i < mti_fnts.length; i++) {
+            fonts.push(new Font(mti_fnts[i]["fontfamily"]));
+          }
+        }
+        onReady(fonts);
+      } else {
+        setTimeout(function() {
+          checkAndLoadIfDownloaded();
+        }, 50);
+      }
     }
     if (projectId) {
-	  var loadWindow = self.domHelper_.getLoadWindow();
+      var loadWindow = self.domHelper_.getLoadWindow();
 
-	  var script = this.domHelper_.loadScript(self.getScriptSrc(projectId, version), function (err) {
-	    if (err) {
-		  onReady([]);
-	    } else {
-		  checkAndLoadIfDownloaded();
-	    }
-	  });
-	  script["id"] = Monotype.SCRIPTID + projectId;
+      var script = this.domHelper_.loadScript(self.getScriptSrc(projectId, version), function(err) {
+        if (err) {
+          onReady([]);
+        } else {
+          checkAndLoadIfDownloaded();
+        }
+      });
+      script["id"] = Monotype.SCRIPTID + projectId;
     } else {
       onReady([]);
     }

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -68,7 +68,7 @@ goog.scope(function () {
 	  } else {
 	    setTimeout(function () {
 	      checkAndLoadIfDownloaded();
-	    }, 0)
+	    }, 50);
 	  }
     }
     if (projectId) {

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -63,11 +63,11 @@ goog.scope(function() {
 
         if (mti_fnts) {
           for (var i = 0; i < mti_fnts.length; i++) {
-            var fnt=mti_fnts[i]["fontfamily"];
+            var fnt = mti_fnts[i]["fontfamily"];
             
             //Check if font-style and font-weight is available
-            if(mti_fnts[i]["fontStyle"]!=undefined && mti_fnts[i]["fontWeight"]!=undefined) {
-              fntVariation=mti_fnts[i]["fontStyle"]+mti_fnts[i]["fontWeight"];
+            if (mti_fnts[i]["fontStyle"] != undefined && mti_fnts[i]["fontWeight"] != undefined) {
+              fntVariation = mti_fnts[i]["fontStyle"] + mti_fnts[i]["fontWeight"];
               fonts.push(new Font(fnt,fntVariation));
             } else {
               fonts.push(new Font(fnt));

--- a/src/modules/monotype.js
+++ b/src/modules/monotype.js
@@ -58,7 +58,7 @@ goog.scope(function() {
     function checkAndLoadIfDownloaded() {
       if (loadWindow[Monotype.HOOK + projectId]) {
         var mti_fnts = loadWindow[Monotype.HOOK + projectId](),
-          fonts = [];
+            fonts = [];
 
         if (mti_fnts) {
           for (var i = 0; i < mti_fnts.length; i++) {


### PR DESCRIPTION
Webfont loader with Monotype module always shows "n4" as font variation description. Monotype users can enable family grouping on their project after adding fonts on the project. When this project is used with google webfont loader, it always shows "n4" as font variation description. So, it is firing single font event for different variation of same font-family.
for more detail: https://github.com/typekit/webfontloader/issues/272

I have updated logic to pass font variation along with font-family.
