### PR TITLE
Fix unquoted numbers in font family names.

### DIFF
--- a/spec/core/font_spec.js
+++ b/spec/core/font_spec.js
@@ -26,6 +26,10 @@ describe('Font', function () {
       expect(quote("'family 1', 'family 2'")).toEqual("'family 1','family 2'");
     });
 
+    it('should quote family names starting with a number', function () {
+      expect(quote('5test')).toEqual("'5test'");
+    });
+
     it('should not quote when there is no space', function () {
       expect(quote('MyFamily')).toEqual('MyFamily');
     });

--- a/src/core/font.js
+++ b/src/core/font.js
@@ -61,7 +61,7 @@ goog.scope(function () {
     var split = name.split(/,\s*/);
     for (var i = 0; i < split.length; i++) {
       var part = split[i].replace(/['"]/g, '');
-      if (part.indexOf(' ') == -1) {
+      if (part.indexOf(' ') == -1 && !(/^\d/.test(part))) {
         quoted.push(part);
       } else {
         quoted.push("'" + part + "'");


### PR DESCRIPTION
This addresses #276. Ideally the `quote` code should be rewritten to cover all corner cases (see https://mathiasbynens.be/notes/unquoted-font-family), but that is out of scope for this bug fix.