### PR TITLE
DomHelper.loadStyleSheet: Make async path more reliable.

### DIFF
--- a/spec/core/domhelper_spec.js
+++ b/spec/core/domhelper_spec.js
@@ -280,6 +280,60 @@ describe('DomHelper', function () {
     });
   });
 
+  describe('#loadStylesheet with callback', function () {
+    it('should load the stylesheet', function () {
+      var el = null,
+          width = null,
+          callbackMade = false;
+
+      function callback() {
+        callbackMade = true;
+      }
+
+      runs(function () {
+        el = domHelper.createElement('div', { id: 'TEST_ELEMENT' });
+        domHelper.insertInto('body', el);
+        width = el.offsetWidth;
+        domHelper.loadStylesheet('fixtures/external_stylesheet.css', callback);
+      });
+
+      waitsFor(function () {
+        return callbackMade;
+      });
+
+      runs(function () {
+        expect(el.offsetWidth).toEqual(300);
+      });
+    });
+  });
+
+  describe('#loadStylesheet with async and callback', function () {
+    it('should load the stylesheet', function () {
+      var el = null,
+          width = null,
+          callbackMade = false;
+
+      function callback() {
+        callbackMade = true;
+      }
+
+      runs(function () {
+        el = domHelper.createElement('div', { id: 'TEST_ELEMENT' });
+        domHelper.insertInto('body', el);
+        width = el.offsetWidth;
+        domHelper.loadStylesheet('fixtures/external_stylesheet.css', callback, true);
+      });
+
+      waitsFor(function () {
+        return callbackMade;
+      });
+
+      runs(function () {
+        expect(el.offsetWidth).toEqual(300);
+      });
+    });
+  });
+
   describe('#loadScript', function () {
     it('should load the script', function () {
       runs(function () {


### PR DESCRIPTION
This change makes sure that opt_callback is called after
the `media` attribute is set to `all` when opt_async is true.

It also adds a couple of tests to cover more of loadStyleSheet().