### PR TITLE
Fonts imported multiple times should pass

### DIFF
--- a/spec/fixtures/fonts/sourcesanse.css
+++ b/spec/fixtures/fonts/sourcesanse.css
@@ -1,0 +1,2 @@
+@font-face{font-family:SourceSansE;src:url(sourcesans.eot?#iefix) format('embedded-opentype'),url(sourcesans.woff) format('woff'),url(sourcesans.otf) format('opentype'),url(sourcesans.ttf) format('truetype'),url(sourcesans.svg#source_sans_proregular) format('svg');}
+@font-face{font-family:SourceSansE;src:url(sourcesans.eot?#iefix) format('embedded-opentype'),url(sourcesans.woff) format('woff'),url(sourcesans.otf) format('opentype'),url(sourcesans.ttf) format('truetype'),url(sourcesans.svg#source_sans_proregular) format('svg');}

--- a/spec/index.html
+++ b/spec/index.html
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="fixtures/fonts/nullfont3.css">
     <link rel="stylesheet" href="fixtures/fonts/sourcesansa.css">
     <link rel="stylesheet" href="fixtures/fonts/sourcesansc.css">
+    <link rel="stylesheet" href="fixtures/fonts/sourcesanse.css">
  </head>
  <body>
     <script>

--- a/src/core/nativefontwatchrunner.js
+++ b/src/core/nativefontwatchrunner.js
@@ -34,7 +34,11 @@ goog.scope(function () {
         reject(that.font_);
       }, that.timeout_);
     }), doc.fonts.load(this.font_.toCssString(), this.fontTestString_)]).then(function (fonts) {
-      if (fonts.length === 1) {
+      var fontReady = false;
+      for (var i = 0; i < fonts.length && !fontReady; i++) {
+        fontReady = fonts[i].status === "loaded";
+      }
+      if (fontReady) {
         that.activeCallback_(that.font_);
       } else {
         that.inactiveCallback_(that.font_);


### PR DESCRIPTION
Our system performs bootstrapping to get everything loaded and in doing so fonts can be loaded multiple times. When run in Chrome the native loader is activated and its explicit check for `fonts.length === 1` in the Promise was causing fonts to fail loading since the length was 2.

I've amended the promise check to be more robust and consider the font loaded if any instance has a `status === "loaded"`. To ensure this is tested going forward I introduced `SourceSansE` which is imported twice and then tested to ensure it still is reported as active. Let me know if you would like this tested differently.

Running spec/index.html in Chrome 46.0.2490.71 (64-bit) and Firefox 41.0.2 (64-bit) all tests pass.