### PR TITLE
Shaved 7mb off published package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "loader",
     "@font-face"
   ],
+  "files": [
+    "webfontloader.js"
+  ],
   "contributors": [
     "Ryan Carver <ryan@typekit.com>",
     "Jeremie Lenfant-engelmann <jeremiele@google.com>",


### PR DESCRIPTION
Right now running `npm install webfontloader` leads to 7mb of extra stuff (e.g. [closure compiler](https://github.com/typekit/webfontloader/tree/master/tools)) being downloaded. With this PR only `webfontloader.js` and the license/readme/changelog will be included.