### PR TITLE
+ other CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To use the Web Font Loader library, just include it in your page and tell it whi
 
 Alternatively, you can link to the latest `1.x` version of the Web Font Loader by using `https://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js` as the `script` source. Note that the version in this url is less specific. It will always load the latest `1.x` version, but it also has a shorter cache time to ensure that your page gets updates in a timely manner. For performance reasons, we recommend using an explicit version number (such as `1.4.7`) in urls when using the Web Font Loader in production. You can manually update the Web Font Loader version number in the url when you want to adopt a new version.
 
+Web Font Loader is also available on the [jsDelivr](http://www.jsdelivr.com/projects/webfontloader) & [CDNJS](https://cdnjs.com/libraries/webfont) CDNs.
+
 It is also possible to use the Web Font Loader asynchronously. For example, to load [Typekit](http://www.typekit.com) fonts asynchronously, you could use the following code.
 
 ```html


### PR DESCRIPTION
Some jsDelivr users find it is faster than googleapis.com in a few areas (namely China).  Also jsDelivr has built in concocting.

CDNJS may also be faster now due to new POPs.