### PR TITLE
Async attribute when using asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ It is also possible to use the Web Font Loader asynchronously. For example, to l
    (function(d) {
       var wf = d.createElement('script'), s = d.scripts[0];
       wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.16/webfont.js';
+      wf.async = true;
       s.parentNode.insertBefore(wf, s);
    })(document);
 </script>


### PR DESCRIPTION
I had to add async attribute to stop Google Page Speed Insights complaining from render-blocking CSS being loaded.
