### PR TITLE
Disable native font loading in Safari 10

### DIFF
--- a/spec/core/fontwatcher_spec.js
+++ b/spec/core/fontwatcher_spec.js
@@ -74,6 +74,12 @@ describe('FontWatcher', function () {
         spyOn(FontWatcher, 'getUserAgent').andReturn('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:43.0) Gecko/20100101 Firefox/43.0');
         expect(FontWatcher.shouldUseNativeLoader()).toEqual(true);
       });
+
+      it('is disabled on Safari > 10', function () {
+        spyOn(FontWatcher, 'getUserAgent').andReturn('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/602.2.14 (KHTML, like Gecko) Version/10.0.1 Safari/602.2.14');
+        spyOn(FontWatcher, 'getVendor').andReturn('Apple');
+        expect(FontWatcher.shouldUseNativeLoader()).toEqual(false);
+      });
     });
   }
 

--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -41,6 +41,13 @@ goog.scope(function () {
   };
 
   /**
+   * @return {string}
+   */
+  FontWatcher.getVendor = function () {
+    return window.navigator.vendor;
+  };
+
+  /**
    * Returns true if this browser has support for
    * the CSS font loading API.
    *
@@ -50,9 +57,12 @@ goog.scope(function () {
     if (FontWatcher.SHOULD_USE_NATIVE_LOADER === null) {
       if (!!window.FontFace) {
         var match = /Gecko.*Firefox\/(\d+)/.exec(FontWatcher.getUserAgent());
+        var safari10Match = /OS X.*Version\/10\..*Safari/.exec(FontWatcher.getUserAgent()) && /Apple/.exec(FontWatcher.getVendor());
 
         if (match) {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = parseInt(match[1], 10) > 42;
+        } else if (safari10Match) {
+          FontWatcher.SHOULD_USE_NATIVE_LOADER = false;
         } else {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = true;
         }


### PR DESCRIPTION
Unfortunately, the native font load API in Safari 10 has two bugs that
cause the document.fonts.load and FontFace.prototype.load methods to
return promises that don't reliably get settled (i.e. either rejected or
resolved).

The bugs are described in more detail here:

https://bugs.webkit.org/show_bug.cgi?id=165037
https://bugs.webkit.org/show_bug.cgi?id=164902

Until patches for these bugs have landed in a stable version this pull
request will disable using the native font loading API on Safari 10. The
code only targets Safari 10 (all versions) because the patches will most
likely land before a new major version is released.