### PR TITLE
[review] Fix Typekit module reading from an old configuration variable.

### DIFF
--- a/spec/modules/typekit_spec.js
+++ b/spec/modules/typekit_spec.js
@@ -15,7 +15,19 @@ describe('modules.Typekit', function () {
     global = {
       Typekit: {
         config: {
-          fn: ['Font1', ['n4'], 'Font2', ['n4', 'n7']]
+          fc: [{
+            family: 'Font1',
+            weight: '400',
+            style: 'normal'
+          },  {
+            family: 'Font2',
+            weight: '400',
+            style: 'normal'
+          }, {
+            family: 'Font2',
+            weight: '700',
+            style: 'normal'
+          }]
         },
         load: jasmine.createSpy('load')
       }

--- a/src/modules/typekit.js
+++ b/src/modules/typekit.js
@@ -39,17 +39,15 @@ goog.scope(function () {
         if (err) {
           onReady([]);
         } else {
-          if (loadWindow['Typekit'] && loadWindow['Typekit']['config'] && loadWindow['Typekit']['config']['fn']) {
-            var fn = loadWindow['Typekit']['config']['fn'],
+          if (loadWindow['Typekit'] && loadWindow['Typekit']['config'] && loadWindow['Typekit']['config']['fc']) {
+            var fc = loadWindow['Typekit']['config']['fc'],
                 fonts = [];
 
-            for (var i = 0; i < fn.length; i += 2) {
-              var font = fn[i],
-                  variations = fn[i + 1];
+            for (var i = 0; i < fc.length; i++) {
+              var fvd = fc[i]['style'].charAt(0) + fc[i]['weight'].charAt(0);
+              var family = fc[i]['family'];
 
-              for (var j = 0; j < variations.length; j++) {
-                fonts.push(new Font(font, variations[j]));
-              }
+              fonts.push(new Font(family, fvd));
             }
 
             // Kick off font loading but disable font events so


### PR DESCRIPTION
The configuration variable read by the Web Font Loader is deprecated. This changes the Web Font Loader to read from the new configuration.