### PR TITLE
Fix 'Uncaught ReferenceError: Promise is not defined' errors on Android devices

### DIFF
--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -64,7 +64,7 @@ goog.scope(function () {
         } else if (safari10Match) {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = false;
         } else {
-          FontWatcher.SHOULD_USE_NATIVE_LOADER = true;
+          FontWatcher.SHOULD_USE_NATIVE_LOADER = !!window.Promise;
         }
       } else {
         FontWatcher.SHOULD_USE_NATIVE_LOADER = false;


### PR DESCRIPTION
I’ve implemented a global window error handler on my page, which logs
all javascript errors on my server. In this error log I get some
„Promise is not defined“ errors caused by the font watcher when running
on some strange Android browser versions. Here are some examples of the UserAgent strings of browsers which have this error:

Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-J700T Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36

Mozilla/5.0 (Linux; Android 7.0; SM-G950U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36

Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G930A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36

Mozilla/5.0 (Linux; Android 7.0; XT1585 Build/NCKS25.118-10-6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36

Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
