### PR TITLE
Fix font fallback Safari 10 for iOS

### DIFF
--- a/src/core/fontwatcher.js
+++ b/src/core/fontwatcher.js
@@ -57,11 +57,14 @@ goog.scope(function () {
     if (FontWatcher.SHOULD_USE_NATIVE_LOADER === null) {
       if (!!window.FontFace) {
         var match = /Gecko.*Firefox\/(\d+)/.exec(FontWatcher.getUserAgent());
-        var safari10Match = /OS X.*Version\/10\..*Safari/.exec(FontWatcher.getUserAgent()) && /Apple/.exec(FontWatcher.getVendor());
+        var appleMatch = /Apple/.exec(FontWatcher.getVendor())
+        var safari10Match = /OS X.*Version\/10\..*Safari/.exec(FontWatcher.getUserAgent()) ||
+                            /AppleWebKit\/603/.exec(FontWatcher.getUserAgent()) ||
+                            /AppleWebKit\/602/.exec(FontWatcher.getUserAgent())
 
         if (match) {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = parseInt(match[1], 10) > 42;
-        } else if (safari10Match) {
+        } else if (appleMatch && safari10Match) {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = false;
         } else {
           FontWatcher.SHOULD_USE_NATIVE_LOADER = true;


### PR DESCRIPTION
## What this PR tries to accomplish
- Partially fixes #365, for the iOS portion. 
    - On Safari 10 for iOS after setting a font, the `FontRuler` will report a width that is different than any of the fallback `FontRuler` widths. 
    - Once the font has loaded, the width is then changed again to the correct width.

- Extend coverage of #352 for iOS devices running Safari 10. 
    - `navigator.userAgent` for iOS devices do not contain `*Version\/10` match which fails the check for when to use the native loader

## How it accomplishes them
> Partially fixes #365, for the iOS portion. 
- Add Safari 10 to the fallback bug check. 
- Create a `FontRuler` for a mock font with the same styling and record the width as a `lastResortWidth`.
- Since the fallback bug is present, the font will be considered loaded when the font width does not match any of the widths in `lastResortWidth`

> Extend coverage of #352 for iOS devices running Safari 10.
- Match on `AppleWebKit` version to determine if webkit version is equivalent to the one used in Safari 10
